### PR TITLE
Add SunPerp Perpetual Futures skill

### DIFF
--- a/sunperp-skill/.gitignore
+++ b/sunperp-skill/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+*.log

--- a/sunperp-skill/README.md
+++ b/sunperp-skill/README.md
@@ -1,0 +1,68 @@
+# SunPerp Perpetual Futures Skill
+
+AI agent skill for trading USDT-margined perpetual futures on [SunPerp](https://www.sunperp.com) (TRON blockchain).
+
+## What This Skill Does
+
+Enables AI agents to interact with SunPerp's REST API to:
+
+- Query real-time market data (prices, order books, candlesticks, funding rates)
+- Manage account (balances, fee rates, trading bills)
+- Place and cancel orders (market, limit, post-only with TP/SL)
+- Manage positions (view, set leverage, set position mode, close)
+
+## Quick Start
+
+### 1. Install Dependencies
+
+```bash
+npm install
+```
+
+### 2. Set API Keys
+
+Create keys at https://www.sunperp.com/futures/api-manage/ then:
+
+```bash
+export SUNPERP_ACCESS_KEY="your_access_key"
+export SUNPERP_SECRET_KEY="your_secret_key"
+```
+
+### 3. Test Connection
+
+```bash
+# Public endpoint (no auth)
+node scripts/market.js ticker contract_code=BTC-USDT
+
+# Authenticated endpoint
+node scripts/account.js balance
+```
+
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `scripts/market.js` | Market data (ticker, depth, kline, funding, etc.) |
+| `scripts/account.js` | Account balance, fee rates, bills |
+| `scripts/order.js` | Place, cancel, query orders |
+| `scripts/position.js` | Positions, leverage, position mode |
+| `scripts/wallet.js` | Withdraw USDT, query deposit/withdraw records |
+| `scripts/utils.js` | Shared auth/signature utilities |
+
+## Important Disclaimer
+
+This skill covers **trading operations only** (placing orders, managing positions, querying market data). It does **not** handle on-chain wallet operations. The agent operator is responsible for:
+
+- **Deposits**: Manually transferring USDT (TRC-20) to the SunPerp platform
+- **Withdrawals**: Manually initiating and confirming withdrawals from SunPerp
+- **Private key management**: Never share private keys with agents or store them in skill files
+
+Ensure the trading account is funded before the agent begins trading.
+
+## For AI Agents
+
+Read `SKILL.md` for complete usage instructions, command reference, examples, and error handling guidance.
+
+## License
+
+MIT

--- a/sunperp-skill/SKILL.md
+++ b/sunperp-skill/SKILL.md
@@ -1,0 +1,628 @@
+---
+name: SunPerp Perpetual Futures Trading
+description: Trade USDT-margined perpetual futures on SunPerp (TRON) — place orders, manage positions, query market data, and manage account via REST API.
+version: 1.0.0
+dependencies:
+  - node >= 18.0.0
+tags:
+  - defi
+  - perpetual
+  - futures
+  - tron
+  - sunperp
+  - trading
+author: bankofai
+homepage: https://www.sunperp.com
+arguments:
+  - name: action
+    description: The trading action to perform (e.g., market_buy, limit_sell, check_balance, get_price)
+    required: true
+  - name: contract_code
+    description: "Trading pair symbol (e.g., BTC-USDT, ETH-USDT, TRX-USDT)"
+    required: false
+  - name: volume
+    description: Number of contracts to trade
+    required: false
+  - name: price
+    description: Limit price for limit orders
+    required: false
+  - name: leverage
+    description: Leverage multiplier (e.g., 10, 20, 50)
+    required: false
+---
+
+# SunPerp Perpetual Futures Trading
+
+## Overview
+
+This skill enables AI agents to trade USDT-margined perpetual futures on [SunPerp](https://www.sunperp.com), the perpetual futures DEX on the TRON blockchain. It provides scripts for:
+
+- **Market data**: Prices, order books, candlesticks, funding rates
+- **Account management**: Balances, fee rates, trading bills
+- **Order management**: Place, cancel, and query orders (market, limit, post-only)
+- **Position management**: View positions, set leverage, set position mode, close positions
+
+All scripts communicate with the SunPerp REST API at `https://api.sunx.io`.
+
+## Prerequisites
+
+### 1. Environment Setup
+
+Install Node.js dependencies from the skill directory:
+
+```bash
+cd <skill_directory>
+npm install
+```
+
+### 2. API Key Configuration
+
+The user must create API keys at https://www.sunperp.com/futures/api-manage/ and set them as environment variables:
+
+```bash
+export SUNPERP_ACCESS_KEY="your_access_key"
+export SUNPERP_SECRET_KEY="your_secret_key"
+```
+
+> [!CAUTION]
+> Never hardcode API keys in commands or files. Always read them from environment variables. If the environment variables are not set, prompt the user to set them before proceeding.
+
+### 3. Verify Setup
+
+Run a public endpoint to verify connectivity (no API key needed):
+
+```bash
+node scripts/market.js ticker contract_code=BTC-USDT
+```
+
+Then verify authenticated access:
+
+```bash
+node scripts/account.js balance
+```
+
+## Usage Instructions
+
+### Contract Code Format
+
+SunPerp contracts follow these naming patterns:
+
+| Type | Format | Example |
+|---|---|---|
+| Perpetual swap | `{SYMBOL}-USDT` | `BTC-USDT` |
+| Current week | `{SYMBOL}-USDT-CW` | `BTC-USDT-CW` |
+| Next week | `{SYMBOL}-USDT-NW` | `BTC-USDT-NW` |
+| Current quarter | `{SYMBOL}-USDT-CQ` | `BTC-USDT-CQ` |
+| Next quarter | `{SYMBOL}-USDT-NQ` | `BTC-USDT-NQ` |
+
+Popular perpetual contracts: `BTC-USDT`, `ETH-USDT`, `TRX-USDT`, `SOL-USDT`, `SUN-USDT`, `DOGE-USDT`, `XRP-USDT`.
+
+### Position Modes
+
+SunPerp supports two position modes:
+
+- **single_side** (One-way): Use `position_side=both` for all orders. The `side` field determines direction.
+- **dual_side** (Hedge): Must specify `position_side=long` or `position_side=short`. Allows simultaneous long and short positions.
+
+Check the current mode before trading:
+
+```bash
+node scripts/position.js get_mode
+```
+
+### Margin Mode
+
+The API uses **cross margin** (`margin_mode=cross`) as the standard mode. All order and position scripts default to cross margin.
+
+---
+
+### Script Reference
+
+All scripts are located in the `scripts/` directory and invoked as:
+
+```bash
+node scripts/<script>.js <command> [key=value ...]
+```
+
+---
+
+### Market Data (scripts/market.js)
+
+No authentication required for market data.
+
+#### Get 24h Ticker
+
+```bash
+node scripts/market.js ticker contract_code=BTC-USDT
+```
+
+Returns: open, close, high, low, volume, best bid/ask.
+
+#### Get Order Book
+
+```bash
+node scripts/market.js depth contract_code=BTC-USDT type=step0
+```
+
+`type` values: `step0` (unmerged, 150 levels) through `step5`; `step6` (unmerged, 20 levels) through `step13`.
+
+#### Get Candlestick Data
+
+```bash
+node scripts/market.js kline contract_code=BTC-USDT period=60min size=50
+```
+
+`period` values: `1min`, `5min`, `15min`, `30min`, `60min`, `60min`, `4hour`, `1day`, `1mon`.
+
+#### Get Best Bid/Offer
+
+```bash
+node scripts/market.js bbo contract_code=BTC-USDT
+```
+
+#### Get Last Trade
+
+```bash
+node scripts/market.js trade contract_code=BTC-USDT
+```
+
+#### Get Recent Trades
+
+```bash
+node scripts/market.js trades contract_code=BTC-USDT size=20
+```
+
+#### Get Funding Rate
+
+```bash
+node scripts/market.js funding contract_code=BTC-USDT
+```
+
+#### Get Index Price
+
+```bash
+node scripts/market.js index contract_code=BTC-USDT
+```
+
+#### List Available Contracts
+
+```bash
+node scripts/market.js contracts
+```
+
+#### Get Price Limits
+
+```bash
+node scripts/market.js price_limit contract_code=BTC-USDT
+```
+
+---
+
+### Account (scripts/account.js)
+
+Requires authentication (API keys).
+
+#### Check Account Balance
+
+```bash
+node scripts/account.js balance
+```
+
+Returns: equity, available margin, unrealized PnL, maintenance margin rate.
+
+#### Get Fee Rates
+
+```bash
+node scripts/account.js fee contract_code=BTC-USDT
+```
+
+#### Get Trading Bills
+
+```bash
+node scripts/account.js bills mar_acct=USDT
+```
+
+Optional: `contract=BTC-USDT`, `start_time=<ms>`, `end_time=<ms>`.
+
+---
+
+### Order Management (scripts/order.js)
+
+Requires authentication with **Trade** permission.
+
+#### Place a Market Order
+
+Open a long position (buy):
+
+```bash
+node scripts/order.js place contract_code=BTC-USDT side=buy type=market volume=1
+```
+
+Open a short position (sell):
+
+```bash
+node scripts/order.js place contract_code=BTC-USDT side=sell type=market volume=1
+```
+
+#### Place a Limit Order
+
+```bash
+node scripts/order.js place contract_code=BTC-USDT side=buy type=limit volume=1 price=95000
+```
+
+#### Place an Order with TP/SL
+
+```bash
+node scripts/order.js place contract_code=BTC-USDT side=buy type=market volume=1 tp_trigger_price=100000 sl_trigger_price=90000
+```
+
+#### Place a Post-Only Order
+
+```bash
+node scripts/order.js place contract_code=BTC-USDT side=buy type=post_only volume=1 price=94000
+```
+
+#### Place an Order in Hedge Mode
+
+When `position_mode=dual_side`, you must specify `position_side`:
+
+```bash
+# Open long
+node scripts/order.js place contract_code=BTC-USDT side=buy type=market volume=1 position_side=long
+
+# Close long
+node scripts/order.js place contract_code=BTC-USDT side=sell type=market volume=1 position_side=long
+
+# Open short
+node scripts/order.js place contract_code=BTC-USDT side=sell type=market volume=1 position_side=short
+
+# Close short
+node scripts/order.js place contract_code=BTC-USDT side=buy type=market volume=1 position_side=short
+```
+
+#### Cancel an Order
+
+```bash
+node scripts/order.js cancel contract_code=BTC-USDT order_id=123456789
+```
+
+Or by client order ID:
+
+```bash
+node scripts/order.js cancel contract_code=BTC-USDT client_order_id=my_order_1
+```
+
+#### Cancel All Orders
+
+```bash
+node scripts/order.js cancel_all
+```
+
+Optionally filter: `contract_code=BTC-USDT`, `side=buy`, `position_side=long`.
+
+#### Close Position for a Symbol
+
+```bash
+node scripts/order.js close contract_code=BTC-USDT position_side=both
+```
+
+In hedge mode use `position_side=long` or `position_side=short`.
+
+#### Close All Positions
+
+```bash
+node scripts/order.js close_all
+```
+
+#### List Open Orders
+
+```bash
+node scripts/order.js open_orders contract_code=BTC-USDT
+```
+
+#### Get Order Info
+
+```bash
+node scripts/order.js info contract_code=BTC-USDT order_id=123456789
+```
+
+#### Get Order History
+
+```bash
+node scripts/order.js history contract_code=BTC-USDT
+```
+
+Optional: `state=filled`, `start_time=<ms>`, `end_time=<ms>`, `limit=50`.
+
+#### Get Execution Details
+
+```bash
+node scripts/order.js details contract_code=BTC-USDT order_id=123456789
+```
+
+---
+
+### Position Management (scripts/position.js)
+
+Requires authentication.
+
+#### List Open Positions
+
+```bash
+node scripts/position.js list
+```
+
+Or for a specific contract:
+
+```bash
+node scripts/position.js list contract_code=BTC-USDT
+```
+
+Returns: entry price, volume, liquidation price, unrealized PnL, margin rate, leverage, ADL risk.
+
+#### Get Current Leverage
+
+```bash
+node scripts/position.js get_leverage contract_code=BTC-USDT
+```
+
+#### Set Leverage
+
+```bash
+node scripts/position.js set_leverage contract_code=BTC-USDT lever_rate=20
+```
+
+> [!WARNING]
+> Increasing leverage increases liquidation risk. Always confirm the desired leverage with the user before setting it.
+
+#### Get Position Mode
+
+```bash
+node scripts/position.js get_mode
+```
+
+#### Set Position Mode
+
+```bash
+node scripts/position.js set_mode position_mode=single_side
+```
+
+> [!NOTE]
+> Position mode can only be changed when there are no open positions or orders.
+
+#### Get Risk Limits
+
+```bash
+node scripts/position.js risk_limit contract_code=BTC-USDT
+```
+
+#### Get Position Limits
+
+```bash
+node scripts/position.js position_limit contract_code=BTC-USDT
+```
+
+---
+
+### Wallet (scripts/wallet.js)
+
+Requires authentication with **Withdraw** permission. Also requires `TRON_PRIVATE_KEY` env var for signing withdrawal confirmations.
+
+```bash
+export TRON_PRIVATE_KEY="your_hex_private_key"
+```
+
+#### Withdraw USDT (Full Flow)
+
+Performs the complete two-step withdraw: apply → sign → confirm.
+
+```bash
+node scripts/wallet.js withdraw address=TXxxxxxxxxxxxxxxxxxxxxxxxxxxxx amount=10
+```
+
+Optional: `currency=usdt` (default), `chain=trc20usdt` (default), `fee=0` (default).
+
+#### Withdraw Apply Only (Step 1)
+
+Returns nonce and content for manual signing:
+
+```bash
+node scripts/wallet.js apply address=TXxxxxxxxxxxxxxxxxxxxxxxxxxxxx amount=10
+```
+
+#### Withdraw Confirm Only (Step 2)
+
+Confirm a previously applied withdrawal with a pre-computed signature:
+
+```bash
+node scripts/wallet.js confirm nonce=<nonce_from_apply> signature=<hex_signature>
+```
+
+#### Query Deposit/Withdraw Records
+
+```bash
+node scripts/wallet.js records type=deposit
+node scripts/wallet.js records type=withdraw
+```
+
+Optional: `currency=usdt`, `size=50`, `direct=next`, `from=<id>`.
+
+> [!CAUTION]
+> Withdrawals move funds off-platform and are irreversible. Always confirm the destination address and amount with the user before executing.
+
+---
+
+## Examples
+
+### Example 1: Check Price and Open a Long Position
+
+```
+User: "Buy 5 contracts of BTC-USDT at market price"
+
+Agent steps:
+1. Check the current price:
+   node scripts/market.js ticker contract_code=BTC-USDT
+
+2. Check account balance:
+   node scripts/account.js balance
+
+3. Confirm with user: "BTC-USDT is currently at $96,500. You have $10,000 available margin.
+   Placing a market buy for 5 contracts. Proceed?"
+
+4. After user confirms, place the order:
+   node scripts/order.js place contract_code=BTC-USDT side=buy type=market volume=5
+
+5. Verify the position was opened:
+   node scripts/position.js list contract_code=BTC-USDT
+
+6. Report: "Opened long position: 5 BTC-USDT contracts at $96,502 avg entry.
+   Liquidation price: $48,251. Current unrealized PnL: $0."
+```
+
+### Example 2: Set Leverage and Place a Limit Order
+
+```
+User: "Set leverage to 20x on ETH-USDT and place a limit buy at $3,200 for 10 contracts"
+
+Agent steps:
+1. Set leverage:
+   node scripts/position.js set_leverage contract_code=ETH-USDT lever_rate=20
+
+2. Check current price for context:
+   node scripts/market.js ticker contract_code=ETH-USDT
+
+3. Confirm with user: "Leverage set to 20x. ETH-USDT is at $3,350.
+   Placing limit buy for 10 contracts at $3,200. Proceed?"
+
+4. After user confirms, place the order:
+   node scripts/order.js place contract_code=ETH-USDT side=buy type=limit volume=10 price=3200
+
+5. Verify the order was placed:
+   node scripts/order.js open_orders contract_code=ETH-USDT
+
+6. Report: "Limit buy order placed: 10 ETH-USDT at $3,200. Order ID: 987654321. Status: open."
+```
+
+### Example 3: Close a Position and Check PnL
+
+```
+User: "Close my BTC-USDT position"
+
+Agent steps:
+1. Check existing position:
+   node scripts/position.js list contract_code=BTC-USDT
+
+2. Report position details and confirm:
+   "You have a long position of 5 BTC-USDT contracts. Entry: $96,502, Current: $97,100.
+   Unrealized PnL: +$2.99. Close at market? Proceed?"
+
+3. After user confirms, close:
+   node scripts/order.js close contract_code=BTC-USDT position_side=both
+
+4. Verify:
+   node scripts/position.js list contract_code=BTC-USDT
+
+5. Report: "Position closed. Realized PnL: +$2.95 after fees."
+```
+
+### Example 4: Monitor Funding Rate
+
+```
+User: "What's the funding rate for TRX-USDT?"
+
+Agent steps:
+1. Get funding rate:
+   node scripts/market.js funding contract_code=TRX-USDT
+
+2. Report: "TRX-USDT funding rate: 0.01% (next funding in 2h 15m).
+   Positive rate means longs pay shorts."
+```
+
+---
+
+## Error Handling
+
+### Common Error Scenarios
+
+| Error | Cause | Resolution |
+|---|---|---|
+| Missing env vars | `SUNPERP_ACCESS_KEY` / `SUNPERP_SECRET_KEY` not set | Ask user to set API keys |
+| `HTTP 401` | Invalid or expired API keys | Ask user to check/regenerate keys |
+| `HTTP 403` | Insufficient permissions | API key needs Trade permission for orders |
+| Timestamp error | System clock skew > 5 minutes | Check system time synchronization |
+| Insufficient margin | Not enough available margin for the order | Show balance, suggest reducing volume or leverage |
+| Position mode conflict | Trying to set mode while positions are open | Close positions first, then switch mode |
+| Order rejected | Price outside limits or volume too small | Check `price_limit` and contract info for min/max |
+
+### Error Handling Pattern
+
+When a script returns an error:
+
+1. Parse the error message from the JSON response (`code`, `message`, or `error-msg` fields)
+2. Explain the error to the user in plain language
+3. Suggest a specific corrective action
+4. Do NOT retry automatically for trade operations — always confirm with the user
+
+---
+
+## Security Considerations
+
+> [!CAUTION]
+> **Private Keys & API Secrets**: Never log, display, or store API secret keys. Read them exclusively from environment variables.
+
+> [!WARNING]
+> **Trade Confirmation**: Always confirm the following with the user BEFORE executing any trade:
+> - Contract code and direction (long/short)
+> - Order type (market/limit) and volume
+> - Price (for limit orders)
+> - Current leverage setting
+> - Estimated margin requirement
+
+### Security Checklist
+
+- [ ] API keys loaded from environment variables only
+- [ ] No secrets in command output or logs
+- [ ] Trade confirmations shown before execution
+- [ ] Leverage changes confirmed before applying
+- [ ] Position mode changes confirmed before applying
+- [ ] Close-all operations require explicit user confirmation
+- [ ] Cancel-all operations require explicit user confirmation
+
+### User Communication Templates
+
+**Pre-trade confirmation:**
+```
+📋 Order Summary:
+  Contract: {contract_code}
+  Side: {side} ({long/short})
+  Type: {type}
+  Volume: {volume} contracts
+  Price: {price or "market"}
+  Leverage: {lever_rate}x
+  Est. margin: ~${margin}
+
+Proceed? (yes/no)
+```
+
+**Post-trade report:**
+```
+✅ Order executed:
+  Order ID: {order_id}
+  Avg. fill price: ${trade_avg_price}
+  Fee: ${fee}
+```
+
+**Position summary:**
+```
+📊 Position: {contract_code} {direction}
+  Volume: {volume} contracts
+  Entry: ${open_avg_price}
+  Mark: ${mark_price}
+  Liq. price: ${liquidation_price}
+  Unrealized PnL: ${profit_unreal} ({profit_rate}%)
+  Leverage: {lever_rate}x
+```
+
+---
+
+*Version 1.0.0 — Created by [M2M Agent Registry](https://m2mregistry.io) for Bank of AI*

--- a/sunperp-skill/SKILL.md
+++ b/sunperp-skill/SKILL.md
@@ -565,6 +565,69 @@ When a script returns an error:
 
 ---
 
+## Agent Safety Locks
+
+Two mandatory safety mechanisms are enforced at the script level to prevent catastrophic losses. Both are configured in `resources/sunperp_config.json` under the `safety` key.
+
+### 1. Max Leverage Cap
+
+| Parameter | Default | Description |
+|---|---|---|
+| `safety.max_leverage` | `20` | Maximum leverage the agent is allowed to use |
+
+The cap is enforced in two places:
+
+- **`position.js set_leverage`** — rejects any `lever_rate` above the cap before calling the API.
+- **`order.js place`** — if `lever_rate` is passed inline, it is validated before the order is submitted.
+
+If the agent attempts to exceed the cap, the script exits with a clear error:
+
+```
+ERROR: Leverage 50x exceeds the agent safety cap of 20x.
+Adjust max_leverage in sunperp_config.json to raise this limit.
+```
+
+To change the cap, edit `safety.max_leverage` in the config file. This is an operator-level setting — the agent cannot change it at runtime.
+
+### 2. Mandatory Stop-Loss
+
+| Parameter | Default | Description |
+|---|---|---|
+| `safety.stop_loss.required` | `true` | Whether every position-opening order must have a stop-loss |
+| `safety.stop_loss.default_percent` | `5` | Auto-calculated SL distance when `sl_trigger_price` is omitted |
+| `safety.stop_loss.max_percent` | `25` | Maximum allowed SL distance — rejects wider stop-losses |
+
+When `required` is `true`, **every position-opening order** (i.e., not `reduce_only`) must include a stop-loss:
+
+- **If `sl_trigger_price` is provided**: validated to be within `max_percent` of the reference price.
+- **If omitted on a limit order**: auto-calculated at `default_percent` below entry (long) or above entry (short).
+- **If omitted on a market order**: the script fetches the current market price and auto-calculates. If the price fetch fails, the order is rejected with an instruction to provide `sl_trigger_price` explicitly.
+
+Example — auto stop-loss on a limit long:
+
+```bash
+# Limit buy at $95,000 — SL auto-set to $90,250 (5% below)
+node scripts/order.js place contract_code=BTC-USDT side=buy type=limit volume=1 price=95000
+```
+
+Example — explicit stop-loss:
+
+```bash
+node scripts/order.js place contract_code=BTC-USDT side=buy type=market volume=1 sl_trigger_price=90000
+```
+
+Example — rejected (SL too wide):
+
+```bash
+# 30% distance exceeds max_percent of 25%
+node scripts/order.js place contract_code=BTC-USDT side=buy type=limit volume=1 price=95000 sl_trigger_price=66500
+```
+
+> [!NOTE]
+> The `reduce_only` flag (close-position orders) is exempt from the stop-loss requirement since those orders are already reducing risk.
+
+---
+
 ## Security Considerations
 
 > [!CAUTION]
@@ -584,6 +647,8 @@ When a script returns an error:
 - [ ] No secrets in command output or logs
 - [ ] Trade confirmations shown before execution
 - [ ] Leverage changes confirmed before applying
+- [ ] Leverage never exceeds `safety.max_leverage` cap
+- [ ] Every position-opening order has a stop-loss attached
 - [ ] Position mode changes confirmed before applying
 - [ ] Close-all operations require explicit user confirmation
 - [ ] Cancel-all operations require explicit user confirmation
@@ -598,7 +663,8 @@ When a script returns an error:
   Type: {type}
   Volume: {volume} contracts
   Price: {price or "market"}
-  Leverage: {lever_rate}x
+  Leverage: {lever_rate}x (cap: {max_leverage}x)
+  Stop-loss: ${sl_trigger_price}
   Est. margin: ~${margin}
 
 Proceed? (yes/no)

--- a/sunperp-skill/SKILL.md
+++ b/sunperp-skill/SKILL.md
@@ -51,7 +51,7 @@ All scripts communicate with the SunPerp REST API at `https://api.sunx.io`.
 Install Node.js dependencies from the skill directory:
 
 ```bash
-cd <skill_directory>
+cd sunperp-skill
 npm install
 ```
 

--- a/sunperp-skill/package-lock.json
+++ b/sunperp-skill/package-lock.json
@@ -1,0 +1,645 @@
+{
+  "name": "@bankofai/sunperp-skill",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@bankofai/sunperp-skill",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^3.3.2",
+        "tronweb": "^6.2.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.4.0",
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ethereum-cryptography": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
+      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.4.2",
+        "@noble/hashes": "1.4.0",
+        "@scure/bip32": "1.4.0",
+        "@scure/bip39": "1.3.0"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.13.5",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.5.tgz",
+      "integrity": "sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/google-protobuf": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tronweb": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tronweb/-/tronweb-6.2.1.tgz",
+      "integrity": "sha512-qDzdz5Qzuc9dfxYzo6yodfwtoIL+C/h1l3HbzwYJwNGgaj/owbzlLROjrlF/3Py7gO8QbTD0v4GuPQRJ1ZzseA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "7.26.10",
+        "axios": "1.13.5",
+        "bignumber.js": "9.1.2",
+        "ethereum-cryptography": "2.2.1",
+        "ethers": "6.13.5",
+        "eventemitter3": "5.0.1",
+        "google-protobuf": "3.21.4",
+        "semver": "7.7.1",
+        "validator": "13.15.23"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/validator": {
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/sunperp-skill/package.json
+++ b/sunperp-skill/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@bankofai/sunperp-skill",
+  "version": "1.0.0",
+  "description": "AI agent skill for perpetual futures trading on SunPerp (TRON)",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "node-fetch": "^3.3.2",
+    "tronweb": "^6.2.1"
+  },
+  "keywords": [
+    "sunperp",
+    "tron",
+    "perpetual",
+    "futures",
+    "defi",
+    "trading",
+    "ai-agent"
+  ],
+  "license": "MIT"
+}

--- a/sunperp-skill/resources/sunperp_config.json
+++ b/sunperp-skill/resources/sunperp_config.json
@@ -1,0 +1,117 @@
+{
+  "api": {
+    "base_url": "https://api.sunx.io",
+    "api_manage_url": "https://www.sunperp.com/futures/api-manage/",
+    "signature_version": "2",
+    "signature_methods": ["HmacSHA256", "Ed25519"],
+    "timestamp_format": "YYYY-MM-DDThh:mm:ss",
+    "timestamp_validity_window_seconds": 300,
+    "wallet_header": {
+      "CLOUD-EXCHANGE": "6X2K9L4V1C"
+    }
+  },
+  "rate_limits": {
+    "public_non_market": "240 requests / 3 seconds / IP",
+    "public_market": "800 requests / second / IP",
+    "private_read": "72 requests / 3 seconds / UID",
+    "private_trade": "72 requests / 3 seconds / UID",
+    "private_general": "144 requests / 3 seconds / UID",
+    "wallet": "20 requests / 2 seconds"
+  },
+  "endpoints": {
+    "public": {
+      "contract_info": "GET /sapi/v1/public/contract_info",
+      "index_price": "GET /sapi/v1/public/index",
+      "risk_limit": "GET /sapi/v1/public/risk/limit",
+      "funding_rate": "GET /sapi/v1/public/funding_rate",
+      "funding_rate_history": "GET /sapi/v1/public/funding_rate_history",
+      "price_limit": "GET /sapi/v1/public/price_limit"
+    },
+    "market": {
+      "depth": "GET /sapi/v1/market/depth",
+      "kline": "GET /sapi/v1/market/history/kline",
+      "ticker": "GET /sapi/v1/market/detail/merged",
+      "last_trade": "GET /sapi/v1/market/trade",
+      "bbo": "GET /sapi/v1/market/bbo",
+      "trade_history": "GET /sapi/v1/market/history/trade",
+      "mark_price_kline": "GET /sapi/v1/index/market/history/linear_swap_mark_price_kline",
+      "premium_index_kline": "GET /sapi/v1/index/market/history/linear_swap_premium_index_kline",
+      "estimated_rate_kline": "GET /sapi/v1/index/market/history/linear_swap_estimated_rate_kline"
+    },
+    "account": {
+      "balance": "GET /sapi/v1/account/balance",
+      "bill_record": "POST /sapi/v1/account/bill_record",
+      "fee_rate": "POST /sapi/v1/account/fee_rate"
+    },
+    "trade": {
+      "order": "POST /sapi/v1/trade/order",
+      "batch_orders": "POST /sapi/v1/trade/batch_orders",
+      "cancel_order": "POST /sapi/v1/trade/cancel_order",
+      "cancel_batch_orders": "POST /sapi/v1/trade/cancel_batch_orders",
+      "cancel_all_orders": "POST /sapi/v1/trade/cancel_all_orders",
+      "close_position": "POST /sapi/v1/trade/position",
+      "close_all_positions": "POST /sapi/v1/trade/position_all",
+      "open_orders": "GET /sapi/v1/trade/order/opens",
+      "order_details": "GET /sapi/v1/trade/order/details",
+      "order_history": "GET /sapi/v1/trade/order/history",
+      "order_info": "GET /sapi/v1/trade/order"
+    },
+    "position": {
+      "open_positions": "GET /sapi/v1/trade/position/opens",
+      "get_leverage": "GET /sapi/v1/position/lever",
+      "set_leverage": "POST /sapi/v1/position/lever",
+      "get_position_mode": "GET /sapi/v1/position/mode",
+      "set_position_mode": "POST /sapi/v1/position/mode",
+      "risk_limit": "GET /sapi/v1/position/risk/limit",
+      "position_limit": "POST /sapi/v1/position/position_limit"
+    },
+    "wallet": {
+      "withdraw_apply": "POST /sapi/v1/sunx/dw/withdraw/apply",
+      "withdraw_confirm": "POST /sapi/v1/sunx/dw/withdraw/confirm",
+      "deposit_withdraw_records": "GET /sapi/v1/sunperp/dw/query/deposit-withdraw"
+    }
+  },
+  "popular_contracts": [
+    "BTC-USDT",
+    "ETH-USDT",
+    "TRX-USDT",
+    "SOL-USDT",
+    "SUN-USDT",
+    "JST-USDT",
+    "WIN-USDT",
+    "BTT-USDT",
+    "DOGE-USDT",
+    "XRP-USDT"
+  ],
+  "contract_code_format": {
+    "perpetual_swap": "{SYMBOL}-USDT",
+    "dated_futures": "{SYMBOL}-USDT-{YYMMDD}",
+    "current_week": "{SYMBOL}-USDT-CW",
+    "next_week": "{SYMBOL}-USDT-NW",
+    "current_quarter": "{SYMBOL}-USDT-CQ",
+    "next_quarter": "{SYMBOL}-USDT-NQ"
+  },
+  "order_types": {
+    "limit": "Limit order with specific price",
+    "market": "Market order at best available price",
+    "post_only": "Maker-only order, rejected if would take"
+  },
+  "time_in_force": {
+    "GTC": "Good-Til-Canceled (default)",
+    "FOK": "Fill-Or-Kill",
+    "IOC": "Immediate-Or-Cancel"
+  },
+  "position_modes": {
+    "single_side": "One-way mode: use position_side='both'",
+    "dual_side": "Hedge mode: specify position_side='long' or 'short'"
+  },
+  "kline_periods": [
+    "1min", "5min", "15min", "30min", "60min",
+    "4hour", "1day", "1mon"
+  ],
+  "depth_types": {
+    "150_levels": ["step0", "step1", "step2", "step3", "step4", "step5"],
+    "20_levels": ["step6", "step7", "step8", "step9", "step10", "step11", "step12", "step13"],
+    "note": "step0/step6 = unmerged; higher numbers = more price aggregation"
+  }
+}

--- a/sunperp-skill/resources/sunperp_config.json
+++ b/sunperp-skill/resources/sunperp_config.json
@@ -1,4 +1,14 @@
 {
+  "safety": {
+    "max_leverage": 20,
+    "stop_loss": {
+      "required": true,
+      "default_percent": 5,
+      "max_percent": 25,
+      "description": "Every new position order must include a stop-loss. If sl_trigger_price is omitted, one is auto-calculated at default_percent below entry (long) or above entry (short). Values beyond max_percent are rejected."
+    },
+    "description": "Agent safety limits. max_leverage caps the leverage the agent can set or trade with. stop_loss enforces automatic stop-loss on every order to prevent liquidation."
+  },
   "api": {
     "base_url": "https://api.sunx.io",
     "api_manage_url": "https://www.sunperp.com/futures/api-manage/",

--- a/sunperp-skill/scripts/account.js
+++ b/sunperp-skill/scripts/account.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * SunPerp Account Script
+ *
+ * Commands:
+ *   balance                          -- Get account balance
+ *   fee     [contract_code=BTC-USDT] -- Get trading fee rates
+ *   bills   mar_acct=USDT [contract=BTC-USDT] [start_time=...] [end_time=...]
+ */
+import { privateGet, privatePost, printJson, exitWithError, parseArgs } from "./utils.js";
+
+const command = process.argv[2];
+const subArgv = ["", "", ...process.argv.slice(3)];
+
+async function main() {
+  switch (command) {
+    case "balance": {
+      const data = await privateGet("/sapi/v1/account/balance");
+      printJson(data);
+      break;
+    }
+
+    case "fee": {
+      const args = parseArgs(subArgv, [], ["contract_code", "pair", "contract_type", "business_type"]);
+      const data = await privatePost("/sapi/v1/account/fee_rate", {}, {
+        contract_code: args.contract_code,
+        pair: args.pair,
+        contract_type: args.contract_type,
+        business_type: args.business_type,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "bills": {
+      const args = parseArgs(subArgv, ["mar_acct"], ["contract", "start_time", "end_time", "direct", "from_id"]);
+      const data = await privatePost("/sapi/v1/account/bill_record", {}, {
+        mar_acct: args.mar_acct,
+        contract: args.contract,
+        start_time: args.start_time,
+        end_time: args.end_time,
+        direct: args.direct,
+        from_id: args.from_id,
+      });
+      printJson(data);
+      break;
+    }
+
+    default:
+      exitWithError(
+        `Unknown command: ${command}\n` +
+        "Available commands: balance, fee, bills"
+      );
+  }
+}
+
+main().catch((err) => exitWithError(err.message));

--- a/sunperp-skill/scripts/market.js
+++ b/sunperp-skill/scripts/market.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * SunPerp Market Data Script
+ *
+ * Commands:
+ *   ticker   contract_code=BTC-USDT
+ *   depth    contract_code=BTC-USDT [type=step0]
+ *   kline    contract_code=BTC-USDT [period=1hour] [size=50]
+ *   bbo      [contract_code=BTC-USDT]
+ *   trade    [contract_code=BTC-USDT]
+ *   trades   contract_code=BTC-USDT [size=20]
+ *   funding  contract_code=BTC-USDT
+ *   index    [contract_code=BTC-USDT]
+ *   contracts [contract_code=BTC-USDT]
+ *   price_limit [contract_code=BTC-USDT]
+ */
+import { publicGet, printJson, exitWithError, parseArgs } from "./utils.js";
+
+const command = process.argv[2];
+// Shift argv so parseArgs starts from index 3
+const subArgv = ["", "", ...process.argv.slice(3)];
+
+async function main() {
+  switch (command) {
+    case "ticker": {
+      const args = parseArgs(subArgv, ["contract_code"]);
+      const data = await publicGet("/sapi/v1/market/detail/merged", {
+        contract_code: args.contract_code,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "depth": {
+      const args = parseArgs(subArgv, ["contract_code"], ["type"]);
+      const data = await publicGet("/sapi/v1/market/depth", {
+        contract_code: args.contract_code,
+        type: args.type || "step0",
+      });
+      printJson(data);
+      break;
+    }
+
+    case "kline": {
+      const args = parseArgs(subArgv, ["contract_code"], ["period", "size"]);
+      const data = await publicGet("/sapi/v1/market/history/kline", {
+        contract_code: args.contract_code,
+        period: args.period || "60min",
+        size: args.size || "50",
+      });
+      printJson(data);
+      break;
+    }
+
+    case "bbo": {
+      const args = parseArgs(subArgv, [], ["contract_code"]);
+      const data = await publicGet("/sapi/v1/market/bbo", {
+        contract_code: args.contract_code,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "trade": {
+      const args = parseArgs(subArgv, [], ["contract_code"]);
+      const data = await publicGet("/sapi/v1/market/trade", {
+        contract_code: args.contract_code,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "trades": {
+      const args = parseArgs(subArgv, ["contract_code"], ["size"]);
+      const data = await publicGet("/sapi/v1/market/history/trade", {
+        contract_code: args.contract_code,
+        size: args.size || "20",
+      });
+      printJson(data);
+      break;
+    }
+
+    case "funding": {
+      const args = parseArgs(subArgv, ["contract_code"]);
+      const data = await publicGet("/sapi/v1/public/funding_rate", {
+        contract_code: args.contract_code,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "index": {
+      const args = parseArgs(subArgv, [], ["contract_code"]);
+      const data = await publicGet("/sapi/v1/public/index", {
+        contract_code: args.contract_code,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "contracts": {
+      const args = parseArgs(subArgv, [], ["contract_code"]);
+      const data = await publicGet("/sapi/v1/public/contract_info", {
+        contract_code: args.contract_code,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "price_limit": {
+      const args = parseArgs(subArgv, [], ["contract_code"]);
+      const data = await publicGet("/sapi/v1/public/price_limit", {
+        contract_code: args.contract_code,
+      });
+      printJson(data);
+      break;
+    }
+
+    default:
+      exitWithError(
+        `Unknown command: ${command}\n` +
+        "Available commands: ticker, depth, kline, bbo, trade, trades, funding, index, contracts, price_limit"
+      );
+  }
+}
+
+main().catch((err) => exitWithError(err.message));

--- a/sunperp-skill/scripts/order.js
+++ b/sunperp-skill/scripts/order.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * SunPerp Order Management Script
+ *
+ * Commands:
+ *   place          -- Place a single order
+ *   cancel         -- Cancel a single order
+ *   cancel_all     -- Cancel all orders
+ *   close          -- Close position for a symbol at market price
+ *   close_all      -- Close all positions at market price
+ *   open_orders    -- List open orders
+ *   info           -- Get order info
+ *   history        -- Get order history
+ *   details        -- Get execution details
+ *
+ * Place order args:
+ *   contract_code=BTC-USDT side=buy type=limit volume=1 [price=50000]
+ *   [margin_mode=cross] [position_side=both] [reduce_only=0]
+ *   [time_in_force=GTC] [tp_trigger_price=...] [sl_trigger_price=...]
+ *   [client_order_id=...]
+ */
+import { privateGet, privatePost, printJson, exitWithError, parseArgs } from "./utils.js";
+
+const command = process.argv[2];
+const subArgv = ["", "", ...process.argv.slice(3)];
+
+async function main() {
+  switch (command) {
+    case "place": {
+      const args = parseArgs(
+        subArgv,
+        ["contract_code", "side", "type", "volume"],
+        [
+          "price", "margin_mode", "position_side", "reduce_only",
+          "time_in_force", "client_order_id", "price_match",
+          "tp_trigger_price", "tp_order_price", "tp_type", "tp_trigger_price_type",
+          "sl_trigger_price", "sl_order_price", "sl_type", "sl_trigger_price_type",
+          "price_protect", "self_match_prevent",
+        ]
+      );
+      const body = {
+        contract_code: args.contract_code,
+        margin_mode: args.margin_mode || "cross",
+        side: args.side,
+        type: args.type,
+        volume: Number(args.volume),
+        price: args.price ? Number(args.price) : undefined,
+        position_side: args.position_side,
+        reduce_only: args.reduce_only !== undefined ? Number(args.reduce_only) : undefined,
+        time_in_force: args.time_in_force,
+        client_order_id: args.client_order_id,
+        price_match: args.price_match,
+        tp_trigger_price: args.tp_trigger_price ? Number(args.tp_trigger_price) : undefined,
+        tp_order_price: args.tp_order_price ? Number(args.tp_order_price) : undefined,
+        tp_type: args.tp_type,
+        tp_trigger_price_type: args.tp_trigger_price_type,
+        sl_trigger_price: args.sl_trigger_price ? Number(args.sl_trigger_price) : undefined,
+        sl_order_price: args.sl_order_price ? Number(args.sl_order_price) : undefined,
+        sl_type: args.sl_type,
+        sl_trigger_price_type: args.sl_trigger_price_type,
+        price_protect: args.price_protect,
+        self_match_prevent: args.self_match_prevent,
+      };
+      const data = await privatePost("/sapi/v1/trade/order", {}, body);
+      printJson(data);
+      break;
+    }
+
+    case "cancel": {
+      const args = parseArgs(subArgv, ["contract_code"], ["order_id", "client_order_id"]);
+      if (!args.order_id && !args.client_order_id) {
+        exitWithError("Either order_id or client_order_id is required");
+      }
+      const data = await privatePost("/sapi/v1/trade/cancel_order", {}, {
+        contract_code: args.contract_code,
+        order_id: args.order_id,
+        client_order_id: args.client_order_id,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "cancel_all": {
+      const args = parseArgs(subArgv, [], ["contract_code", "side", "position_side"]);
+      const data = await privatePost("/sapi/v1/trade/cancel_all_orders", {}, {
+        contract_code: args.contract_code,
+        side: args.side,
+        position_side: args.position_side,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "close": {
+      const args = parseArgs(subArgv, ["contract_code", "position_side"], ["margin_mode", "client_order_id"]);
+      const data = await privatePost("/sapi/v1/trade/position", {}, {
+        contract_code: args.contract_code,
+        margin_mode: args.margin_mode || "cross",
+        position_side: args.position_side,
+        client_order_id: args.client_order_id,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "close_all": {
+      const data = await privatePost("/sapi/v1/trade/position_all", {}, {});
+      printJson(data);
+      break;
+    }
+
+    case "open_orders": {
+      const args = parseArgs(subArgv, [], ["contract_code", "margin_mode", "limit", "direct"]);
+      const data = await privateGet("/sapi/v1/trade/order/opens", {
+        contract_code: args.contract_code,
+        margin_mode: args.margin_mode,
+        limit: args.limit,
+        direct: args.direct,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "info": {
+      const args = parseArgs(subArgv, ["contract_code"], ["order_id", "client_order_id", "margin_mode"]);
+      if (!args.order_id && !args.client_order_id) {
+        exitWithError("Either order_id or client_order_id is required");
+      }
+      const data = await privateGet("/sapi/v1/trade/order", {
+        contract_code: args.contract_code,
+        order_id: args.order_id,
+        client_order_id: args.client_order_id,
+        margin_mode: args.margin_mode,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "history": {
+      const args = parseArgs(subArgv, ["contract_code"], ["margin_mode", "state", "type", "start_time", "end_time", "limit", "direct"]);
+      const data = await privateGet("/sapi/v1/trade/order/history", {
+        contract_code: args.contract_code,
+        margin_mode: args.margin_mode || "cross",
+        state: args.state,
+        type: args.type,
+        start_time: args.start_time,
+        end_time: args.end_time,
+        limit: args.limit,
+        direct: args.direct,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "details": {
+      const args = parseArgs(subArgv, [], ["contract_code", "order_id", "start_time", "end_time", "limit", "direct"]);
+      const data = await privateGet("/sapi/v1/trade/order/details", {
+        contract_code: args.contract_code,
+        order_id: args.order_id,
+        start_time: args.start_time,
+        end_time: args.end_time,
+        limit: args.limit,
+        direct: args.direct,
+      });
+      printJson(data);
+      break;
+    }
+
+    default:
+      exitWithError(
+        `Unknown command: ${command}\n` +
+        "Available commands: place, cancel, cancel_all, close, close_all, open_orders, info, history, details"
+      );
+  }
+}
+
+main().catch((err) => exitWithError(err.message));

--- a/sunperp-skill/scripts/order.js
+++ b/sunperp-skill/scripts/order.js
@@ -19,7 +19,7 @@
  *   [time_in_force=GTC] [tp_trigger_price=...] [sl_trigger_price=...]
  *   [client_order_id=...]
  */
-import { privateGet, privatePost, printJson, exitWithError, parseArgs } from "./utils.js";
+import { privateGet, privatePost, publicGet, printJson, exitWithError, parseArgs, validateLeverage, enforceStopLoss } from "./utils.js";
 
 const command = process.argv[2];
 const subArgv = ["", "", ...process.argv.slice(3)];
@@ -35,9 +35,17 @@ async function main() {
           "time_in_force", "client_order_id", "price_match",
           "tp_trigger_price", "tp_order_price", "tp_type", "tp_trigger_price_type",
           "sl_trigger_price", "sl_order_price", "sl_type", "sl_trigger_price_type",
-          "price_protect", "self_match_prevent",
+          "price_protect", "self_match_prevent", "lever_rate",
         ]
       );
+
+      // --- Safety: Max Leverage Cap ---
+      // If lever_rate is provided inline, validate it against the cap.
+      // Also check current leverage for the contract.
+      if (args.lever_rate) {
+        validateLeverage(Number(args.lever_rate));
+      }
+
       const body = {
         contract_code: args.contract_code,
         margin_mode: args.margin_mode || "cross",
@@ -61,6 +69,25 @@ async function main() {
         price_protect: args.price_protect,
         self_match_prevent: args.self_match_prevent,
       };
+
+      // --- Safety: Mandatory Stop-Loss ---
+      // Determine reference price for stop-loss calculation
+      let referencePrice = body.price; // limit price if available
+      if (!referencePrice) {
+        // For market orders, fetch current market price as reference
+        try {
+          const ticker = await publicGet("/sapi/v1/market/detail/merged", {
+            contract_code: args.contract_code,
+          });
+          if (ticker.tick && ticker.tick.close) {
+            referencePrice = Number(ticker.tick.close);
+          }
+        } catch {
+          // If ticker fetch fails, enforceStopLoss will require explicit sl_trigger_price
+        }
+      }
+      enforceStopLoss(body, referencePrice);
+
       const data = await privatePost("/sapi/v1/trade/order", {}, body);
       printJson(data);
       break;

--- a/sunperp-skill/scripts/position.js
+++ b/sunperp-skill/scripts/position.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * SunPerp Position Management Script
+ *
+ * Commands:
+ *   list             [contract_code=BTC-USDT]     -- List open positions
+ *   get_leverage     [contract_code=BTC-USDT]     -- Get current leverage
+ *   set_leverage     contract_code=BTC-USDT lever_rate=10  -- Set leverage
+ *   get_mode                                       -- Get position mode (single_side/dual_side)
+ *   set_mode         position_mode=single_side     -- Set position mode
+ *   risk_limit       [contract_code=BTC-USDT]     -- Get risk limits
+ *   position_limit   [contract_code=BTC-USDT]     -- Get position limits
+ */
+import { privateGet, privatePost, printJson, exitWithError, parseArgs } from "./utils.js";
+
+const command = process.argv[2];
+const subArgv = ["", "", ...process.argv.slice(3)];
+
+async function main() {
+  switch (command) {
+    case "list": {
+      const args = parseArgs(subArgv, [], ["contract_code"]);
+      const data = await privateGet("/sapi/v1/trade/position/opens", {
+        contract_code: args.contract_code,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "get_leverage": {
+      const args = parseArgs(subArgv, [], ["contract_code", "margin_mode"]);
+      const data = await privateGet("/sapi/v1/position/lever", {
+        contract_code: args.contract_code,
+        margin_mode: args.margin_mode,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "set_leverage": {
+      const args = parseArgs(subArgv, ["contract_code", "lever_rate"], ["margin_mode"]);
+      const data = await privatePost("/sapi/v1/position/lever", {}, {
+        contract_code: args.contract_code,
+        margin_mode: args.margin_mode || "cross",
+        lever_rate: Number(args.lever_rate),
+      });
+      printJson(data);
+      break;
+    }
+
+    case "get_mode": {
+      const args = parseArgs(subArgv, [], ["margin_mode"]);
+      const data = await privateGet("/sapi/v1/position/mode", {
+        margin_mode: args.margin_mode,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "set_mode": {
+      const args = parseArgs(subArgv, ["position_mode"]);
+      const data = await privatePost("/sapi/v1/position/mode", {}, {
+        position_mode: args.position_mode,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "risk_limit": {
+      const args = parseArgs(subArgv, [], ["contract_code", "margin_mode", "position_side"]);
+      const data = await privateGet("/sapi/v1/position/risk/limit", {
+        contract_code: args.contract_code,
+        margin_mode: args.margin_mode,
+        position_side: args.position_side,
+      });
+      printJson(data);
+      break;
+    }
+
+    case "position_limit": {
+      const args = parseArgs(subArgv, [], ["contract_code", "pair", "contract_type", "business_type"]);
+      const data = await privatePost("/sapi/v1/position/position_limit", {}, {
+        contract_code: args.contract_code,
+        pair: args.pair,
+        contract_type: args.contract_type,
+        business_type: args.business_type,
+      });
+      printJson(data);
+      break;
+    }
+
+    default:
+      exitWithError(
+        `Unknown command: ${command}\n` +
+        "Available commands: list, get_leverage, set_leverage, get_mode, set_mode, risk_limit, position_limit"
+      );
+  }
+}
+
+main().catch((err) => exitWithError(err.message));

--- a/sunperp-skill/scripts/position.js
+++ b/sunperp-skill/scripts/position.js
@@ -11,7 +11,7 @@
  *   risk_limit       [contract_code=BTC-USDT]     -- Get risk limits
  *   position_limit   [contract_code=BTC-USDT]     -- Get position limits
  */
-import { privateGet, privatePost, printJson, exitWithError, parseArgs } from "./utils.js";
+import { privateGet, privatePost, printJson, exitWithError, parseArgs, validateLeverage } from "./utils.js";
 
 const command = process.argv[2];
 const subArgv = ["", "", ...process.argv.slice(3)];
@@ -39,6 +39,7 @@ async function main() {
 
     case "set_leverage": {
       const args = parseArgs(subArgv, ["contract_code", "lever_rate"], ["margin_mode"]);
+      validateLeverage(Number(args.lever_rate));
       const data = await privatePost("/sapi/v1/position/lever", {}, {
         contract_code: args.contract_code,
         margin_mode: args.margin_mode || "cross",

--- a/sunperp-skill/scripts/utils.js
+++ b/sunperp-skill/scripts/utils.js
@@ -1,0 +1,240 @@
+import crypto from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const CONFIG = JSON.parse(
+  readFileSync(join(__dirname, "..", "resources", "sunperp_config.json"), "utf8")
+);
+const BASE_URL = CONFIG.api.base_url;
+
+// ---------------------------------------------------------------------------
+// Environment helpers
+// ---------------------------------------------------------------------------
+
+export function getCredentials() {
+  const accessKey = process.env.SUNPERP_ACCESS_KEY;
+  const secretKey = process.env.SUNPERP_SECRET_KEY;
+  if (!accessKey || !secretKey) {
+    throw new Error(
+      "Missing SUNPERP_ACCESS_KEY or SUNPERP_SECRET_KEY environment variables. " +
+      `Create API keys at ${CONFIG.api.api_manage_url}`
+    );
+  }
+  return { accessKey, secretKey };
+}
+
+// ---------------------------------------------------------------------------
+// Timestamp
+// ---------------------------------------------------------------------------
+
+function utcTimestamp() {
+  // Format: YYYY-MM-DDThh:mm:ss
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "");
+}
+
+// ---------------------------------------------------------------------------
+// Signature (HmacSHA256)
+// ---------------------------------------------------------------------------
+
+function buildSignaturePayload(method, path, sortedParams) {
+  const paramString = sortedParams
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join("&");
+  return `${method}\napi.sunx.io\n${path}\n${paramString}`;
+}
+
+function sign(secretKey, payload) {
+  return crypto
+    .createHmac("sha256", secretKey)
+    .update(payload, "utf8")
+    .digest("base64");
+}
+
+function buildAuthParams(accessKey) {
+  return {
+    AccessKeyId: accessKey,
+    SignatureMethod: "HmacSHA256",
+    SignatureVersion: "2",
+    Timestamp: utcTimestamp(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Request helpers
+// ---------------------------------------------------------------------------
+
+export async function publicGet(path, params = {}) {
+  const qs = Object.entries(params)
+    .filter(([, v]) => v !== undefined && v !== null && v !== "")
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join("&");
+  const url = `${BASE_URL}${path}${qs ? "?" + qs : ""}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+export async function privateGet(path, params = {}) {
+  const { accessKey, secretKey } = getCredentials();
+  const authParams = buildAuthParams(accessKey);
+
+  const allParams = { ...params, ...authParams };
+  // Remove undefined/null
+  for (const k of Object.keys(allParams)) {
+    if (allParams[k] === undefined || allParams[k] === null || allParams[k] === "") {
+      delete allParams[k];
+    }
+  }
+
+  const sorted = Object.entries(allParams).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  const payload = buildSignaturePayload("GET", path, sorted);
+  const signature = sign(secretKey, payload);
+
+  const qs = sorted
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join("&") + `&Signature=${encodeURIComponent(signature)}`;
+
+  const url = `${BASE_URL}${path}?${qs}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+export async function privatePost(path, params = {}, body = {}) {
+  const { accessKey, secretKey } = getCredentials();
+  const authParams = buildAuthParams(accessKey);
+
+  // Query params for signature (auth params only for POST)
+  const queryParams = { ...authParams };
+  const sorted = Object.entries(queryParams).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  const payload = buildSignaturePayload("POST", path, sorted);
+  const signature = sign(secretKey, payload);
+
+  const qs = sorted
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join("&") + `&Signature=${encodeURIComponent(signature)}`;
+
+  const url = `${BASE_URL}${path}?${qs}`;
+
+  // Clean body
+  const cleanBody = {};
+  for (const [k, v] of Object.entries(body)) {
+    if (v !== undefined && v !== null && v !== "") {
+      cleanBody[k] = v;
+    }
+  }
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(cleanBody),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+export async function walletPost(path, body = {}) {
+  const { accessKey, secretKey } = getCredentials();
+  const authParams = buildAuthParams(accessKey);
+
+  // Wallet endpoints: signature path excludes /sapi/v1 prefix
+  const signPath = path.replace(/^\/sapi\/v1/, "");
+
+  const sorted = Object.entries(authParams).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  const payload = buildSignaturePayload("POST", signPath, sorted);
+  const signature = sign(secretKey, payload);
+
+  const qs = sorted
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join("&") + `&Signature=${encodeURIComponent(signature)}`;
+
+  const url = `${BASE_URL}${path}?${qs}`;
+
+  const cleanBody = {};
+  for (const [k, v] of Object.entries(body)) {
+    if (v !== undefined && v !== null && v !== "") {
+      cleanBody[k] = v;
+    }
+  }
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "CLOUD-EXCHANGE": CONFIG.api.wallet_header["CLOUD-EXCHANGE"],
+    },
+    body: JSON.stringify(cleanBody),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+export async function walletGet(path, params = {}) {
+  const { accessKey, secretKey } = getCredentials();
+  const authParams = buildAuthParams(accessKey);
+
+  const signPath = path.replace(/^\/sapi\/v1/, "");
+  const allParams = { ...params, ...authParams };
+  for (const k of Object.keys(allParams)) {
+    if (allParams[k] === undefined || allParams[k] === null || allParams[k] === "") {
+      delete allParams[k];
+    }
+  }
+
+  const sorted = Object.entries(allParams).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  const payload = buildSignaturePayload("GET", signPath, sorted);
+  const signature = sign(secretKey, payload);
+
+  const qs = sorted
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join("&") + `&Signature=${encodeURIComponent(signature)}`;
+
+  const url = `${BASE_URL}${path}?${qs}`;
+  const res = await fetch(url, {
+    headers: {
+      "CLOUD-EXCHANGE": CONFIG.api.wallet_header["CLOUD-EXCHANGE"],
+    },
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Output helpers
+// ---------------------------------------------------------------------------
+
+export function printJson(data) {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+export function exitWithError(msg) {
+  console.error(`ERROR: ${msg}`);
+  process.exit(1);
+}
+
+export function parseArgs(argv, required = [], optional = []) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const [key, ...rest] = argv[i].split("=");
+    args[key] = rest.join("=") || "true";
+  }
+  for (const r of required) {
+    if (!(r in args)) {
+      exitWithError(
+        `Missing required argument: ${r}\n` +
+        `Usage: node <script> ${required.map((r) => `${r}=<value>`).join(" ")} ` +
+        `${optional.map((o) => `[${o}=<value>]`).join(" ")}`
+      );
+    }
+  }
+  return args;
+}
+
+export { CONFIG, BASE_URL };

--- a/sunperp-skill/scripts/utils.js
+++ b/sunperp-skill/scripts/utils.js
@@ -13,6 +13,7 @@ const CONFIG = JSON.parse(
   readFileSync(join(__dirname, "..", "resources", "sunperp_config.json"), "utf8")
 );
 const BASE_URL = CONFIG.api.base_url;
+const SAFETY = CONFIG.safety;
 
 // ---------------------------------------------------------------------------
 // Environment helpers
@@ -237,4 +238,80 @@ export function parseArgs(argv, required = [], optional = []) {
   return args;
 }
 
-export { CONFIG, BASE_URL };
+// ---------------------------------------------------------------------------
+// Safety enforcement
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate leverage against the configured max_leverage cap.
+ * Exits with an error if the requested leverage exceeds the limit.
+ */
+export function validateLeverage(leverRate) {
+  const max = SAFETY.max_leverage;
+  if (leverRate > max) {
+    exitWithError(
+      `Leverage ${leverRate}x exceeds the agent safety cap of ${max}x. ` +
+      `Adjust max_leverage in sunperp_config.json to raise this limit.`
+    );
+  }
+}
+
+/**
+ * Enforce mandatory stop-loss on position-opening orders.
+ * If sl_trigger_price is already set, validates it's within max_percent of the reference price.
+ * If omitted and required=true, auto-calculates one at default_percent from the reference price.
+ *
+ * @param {object} orderBody - the order body being built (mutated in place)
+ * @param {number|null} referencePrice - the limit price or current market price
+ */
+export function enforceStopLoss(orderBody, referencePrice) {
+  const sl = SAFETY.stop_loss;
+  if (!sl.required) return;
+
+  // Only enforce on position-opening orders (not reduce_only / close)
+  if (orderBody.reduce_only === 1) return;
+
+  const side = orderBody.side; // buy = long, sell = short
+  const price = orderBody.sl_trigger_price;
+
+  if (price != null) {
+    // Validate the user-supplied stop-loss is within max_percent
+    if (referencePrice) {
+      const distance = Math.abs(price - referencePrice) / referencePrice * 100;
+      if (distance > sl.max_percent) {
+        exitWithError(
+          `Stop-loss distance of ${distance.toFixed(1)}% exceeds the maximum allowed ${sl.max_percent}%. ` +
+          `Set a tighter sl_trigger_price.`
+        );
+      }
+    }
+    return;
+  }
+
+  // Auto-calculate stop-loss if omitted
+  if (!referencePrice) {
+    // For market orders without a reference price, we can't auto-calculate.
+    // The agent MUST provide sl_trigger_price for market orders.
+    exitWithError(
+      "Stop-loss is required for all position-opening orders. " +
+      "For market orders, provide sl_trigger_price explicitly (e.g., sl_trigger_price=90000)."
+    );
+    return;
+  }
+
+  const pct = sl.default_percent / 100;
+  if (side === "buy") {
+    // Long: stop-loss below entry
+    orderBody.sl_trigger_price = Math.round(referencePrice * (1 - pct) * 100) / 100;
+  } else {
+    // Short: stop-loss above entry
+    orderBody.sl_trigger_price = Math.round(referencePrice * (1 + pct) * 100) / 100;
+  }
+
+  console.error(
+    `AUTO STOP-LOSS: Set sl_trigger_price=${orderBody.sl_trigger_price} ` +
+    `(${sl.default_percent}% from reference price ${referencePrice})`
+  );
+}
+
+export { CONFIG, BASE_URL, SAFETY };

--- a/sunperp-skill/scripts/wallet.js
+++ b/sunperp-skill/scripts/wallet.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * SunPerp Wallet Script
+ *
+ * Commands:
+ *   withdraw  address=TXxx... amount=1 [currency=usdt] [chain=trc20usdt] [fee=0]
+ *             Full withdraw flow: apply → sign with TRON key → confirm
+ *             Requires TRON_PRIVATE_KEY env var for signing the confirm step.
+ *
+ *   apply     address=TXxx... amount=1 [currency=usdt] [chain=trc20usdt] [fee=0]
+ *             Step 1 only: returns nonce + content for manual signing.
+ *
+ *   confirm   nonce=<nonce> signature=<hex_signature>
+ *             Step 2 only: confirm a previously applied withdrawal.
+ *
+ *   records   type=deposit|withdraw [currency=usdt] [size=50] [direct=next] [from=<id>]
+ *             Query deposit or withdrawal history.
+ */
+import { TronWeb } from "tronweb";
+import { walletPost, walletGet, printJson, exitWithError, parseArgs } from "./utils.js";
+
+const command = process.argv[2];
+const subArgv = ["", "", ...process.argv.slice(3)];
+
+function getTronPrivateKey() {
+  const pk = process.env.TRON_PRIVATE_KEY;
+  if (!pk) {
+    exitWithError(
+      "Missing TRON_PRIVATE_KEY environment variable.\n" +
+      "Set it to sign withdrawal confirmations:\n" +
+      '  export TRON_PRIVATE_KEY="your_hex_private_key"'
+    );
+  }
+  return pk;
+}
+
+async function signContent(content) {
+  const pk = getTronPrivateKey();
+  const tronWeb = new TronWeb({ fullHost: "https://api.trongrid.io", privateKey: pk });
+  const signed = await tronWeb.trx.signMessageV2(content);
+  return signed;
+}
+
+async function main() {
+  switch (command) {
+    // ----- Full withdraw: apply → sign → confirm -----
+    case "withdraw": {
+      const args = parseArgs(subArgv, ["address", "amount"], ["currency", "chain", "fee"]);
+
+      // Step 1: Apply
+      console.log("Step 1/2: Submitting withdraw request...");
+      const applyResult = await walletPost("/sapi/v1/sunperp/dw/withdraw/apply", {
+        address: args.address,
+        currency: args.currency || "usdt",
+        chain: args.chain || "trc20usdt",
+        amount: args.amount,
+        fee: args.fee || "0",
+      });
+
+      if (applyResult.status === "error" || applyResult["error-code"]) {
+        exitWithError(
+          `Withdraw apply failed: ${applyResult["error-msg"] || applyResult.message || JSON.stringify(applyResult)}`
+        );
+      }
+
+      const { nonce, content } = applyResult.data;
+      const expiresAt = applyResult.data["expired-at"];
+      console.log(`  Nonce: ${nonce}`);
+      console.log(`  Expires: ${new Date(expiresAt).toISOString()} (120s window)`);
+      console.log(`  Content to sign: ${content}`);
+
+      // Step 2: Sign + Confirm
+      console.log("\nStep 2/2: Signing and confirming...");
+      const signature = await signContent(content);
+      console.log(`  Signature: ${signature}`);
+
+      const confirmResult = await walletPost("/sapi/v1/sunperp/dw/withdraw/confirm", {
+        nonce,
+        signature,
+      });
+
+      if (confirmResult.status === "error" || confirmResult["error-code"]) {
+        exitWithError(
+          `Withdraw confirm failed: ${confirmResult["error-msg"] || confirmResult.message || JSON.stringify(confirmResult)}`
+        );
+      }
+
+      console.log("\nWithdrawal submitted successfully:");
+      printJson(confirmResult);
+      break;
+    }
+
+    // ----- Apply only (step 1) -----
+    case "apply": {
+      const args = parseArgs(subArgv, ["address", "amount"], ["currency", "chain", "fee"]);
+      const data = await walletPost("/sapi/v1/sunperp/dw/withdraw/apply", {
+        address: args.address,
+        currency: args.currency || "usdt",
+        chain: args.chain || "trc20usdt",
+        amount: args.amount,
+        fee: args.fee || "0",
+      });
+      printJson(data);
+      break;
+    }
+
+    // ----- Confirm only (step 2) -----
+    case "confirm": {
+      const args = parseArgs(subArgv, ["nonce", "signature"]);
+      const data = await walletPost("/sapi/v1/sunperp/dw/withdraw/confirm", {
+        nonce: args.nonce,
+        signature: args.signature,
+      });
+      printJson(data);
+      break;
+    }
+
+    // ----- Deposit/Withdraw records -----
+    case "records": {
+      const args = parseArgs(subArgv, ["type"], ["currency", "size", "direct", "from"]);
+      const data = await walletGet("/sapi/v1/sunperp/dw/query/deposit-withdraw", {
+        type: args.type,
+        currency: args.currency,
+        size: args.size,
+        direct: args.direct,
+        from: args.from,
+      });
+      printJson(data);
+      break;
+    }
+
+    default:
+      exitWithError(
+        `Unknown command: ${command}\n` +
+        "Available commands: withdraw, apply, confirm, records"
+      );
+  }
+}
+
+main().catch((err) => exitWithError(err.message));


### PR DESCRIPTION
## Summary
- Adds `sunperp-skill` for trading USDT-margined perpetual futures on SunPerp (TRON)
- Query real-time market data (prices, order books, candlesticks, funding rates)
- Manage account (balances, fee rates, trading bills)
- Place and cancel orders (market, limit, post-only with TP/SL)
- Manage positions (view, set leverage, set position mode, close)

## Scripts
- `market.js` — Real-time market data and funding rates
- `account.js` — Account balances and fee rates
- `order.js` — Place, cancel, and query orders
- `position.js` — View and manage positions
- `wallet.js` — Wallet connection utilities

Source: https://github.com/M2M-TRC8004-Registry/sunperp-skill