### PR TITLE
Add Energy & Bandwidth Manager skill

### DIFF
--- a/energy-bandwidth-skill/.gitignore
+++ b/energy-bandwidth-skill/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/energy-bandwidth-skill/README.md
+++ b/energy-bandwidth-skill/README.md
@@ -1,0 +1,26 @@
+# Energy & Bandwidth Manager
+
+> Monitor and manage TRON's Energy and Bandwidth resource system.
+
+## Scripts
+
+- `status.js` — Resource balances (energy, bandwidth, frozen TRX, pending unstakes)
+- `estimate.js` — Estimate energy cost for a contract call
+- `stake.js` — Stake TRX for Energy or Bandwidth
+- `unstake.js` — Begin unstake (14-day cooldown) or withdraw expired
+- `delegate.js` — Delegate/undelegate resources to other accounts
+
+## Quick Start
+
+```bash
+cd energy-bandwidth && npm install
+export TRON_PRIVATE_KEY="<key>"
+
+node scripts/status.js
+node scripts/stake.js 100 ENERGY --dry-run
+```
+
+## Dependencies
+
+- Node.js 18+
+- [tronweb](https://www.npmjs.com/package/tronweb) ^6.0.0

--- a/energy-bandwidth-skill/README.md
+++ b/energy-bandwidth-skill/README.md
@@ -13,7 +13,7 @@
 ## Quick Start
 
 ```bash
-cd energy-bandwidth && npm install
+cd energy-bandwidth-skill && npm install
 export TRON_PRIVATE_KEY="<key>"
 
 node scripts/status.js

--- a/energy-bandwidth-skill/SKILL.md
+++ b/energy-bandwidth-skill/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: Energy & Bandwidth Manager
+description: Monitor and manage TRON's Energy and Bandwidth resource system — stake, unstake, delegate, and estimate costs.
+version: 1.0.0
+dependencies:
+  - node >= 18.0.0
+  - tronweb
+tags:
+  - tron
+  - energy
+  - bandwidth
+  - staking
+  - resources
+---
+
+# Energy & Bandwidth Manager
+
+Manage TRON's unique resource system. Energy is consumed by smart contract execution; Bandwidth is consumed by transaction byte-size. Both are obtained by staking (freezing) TRX. This skill lets agents check resource balances, estimate costs, stake/unstake TRX for resources, and delegate resources to other accounts.
+
+---
+
+## Quick Start
+
+```bash
+cd energy-bandwidth && npm install
+export TRON_PRIVATE_KEY="<your-private-key>"
+export TRON_NETWORK="mainnet"
+```
+
+> [!CAUTION]
+> **Never display or log the private key.**
+
+---
+
+## Available Scripts
+
+### 1. `status.js` — Resource Overview
+
+```bash
+node scripts/status.js                    # Own wallet
+node scripts/status.js TWalletAddress     # Specific wallet
+```
+
+**Output:** `energy` (available, limit, used, frozen_trx), `bandwidth` (available, limit, used, free_limit, frozen_trx), `pending_unstakes[]`
+
+### 2. `estimate.js` — Estimate Energy Cost
+
+```bash
+node scripts/estimate.js <contractAddress> <functionSelector> [params] [callValue]
+node scripts/estimate.js TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t "transfer(address,uint256)" "TRecipient,1000000"
+```
+
+**Output:** `estimated_energy`, `contract`, `function`
+
+### 3. `stake.js` — Stake TRX for Resources
+
+```bash
+node scripts/stake.js 100 ENERGY --dry-run
+node scripts/stake.js 50 BANDWIDTH
+```
+
+### 4. `unstake.js` — Unstake TRX (14-day Cooldown)
+
+```bash
+node scripts/unstake.js 50 ENERGY --dry-run       # Begin cooldown
+node scripts/unstake.js --withdraw --dry-run       # Claim expired unstakes
+```
+
+> [!WARNING]
+> Unstaking begins a **14-day cooldown**. During this period the TRX is locked and does not earn resources. After 14 days, use `--withdraw` to claim.
+
+### 5. `delegate.js` — Delegate Resources
+
+```bash
+node scripts/delegate.js TRecipient 100 ENERGY --dry-run
+node scripts/delegate.js --undelegate TRecipient 100 ENERGY --dry-run
+```
+
+---
+
+## TRON Resource Key Facts
+
+| Property | Value |
+|---|---|
+| Free bandwidth per day | 600 points |
+| Energy source | Stake TRX for ENERGY |
+| Bandwidth source | Stake TRX for BANDWIDTH + 600 free/day |
+| Unstake cooldown | 14 days |
+| Delegation | Can delegate to other accounts |
+
+---
+
+## Security Rules
+
+1. **Never display private keys.**
+2. **Always dry-run before staking/unstaking.** These operations lock TRX.
+3. **Warn about the 14-day unstake cooldown.** Users must understand the lockup.
+4. **Check resource status before operations** to avoid staking more than needed.
+
+---
+
+## Common Issues
+
+| Problem | Solution |
+|---|---|
+| `Insufficient TRX` | Check balance with `status.js` first |
+| `No expired unstakes` | Wait for the 14-day cooldown to complete |
+| Energy estimate returns 0 | Function may be view-only (no energy needed) |
+
+---
+
+*Version 1.0.0 — Created by [M2M Agent Registry](https://m2mregistry.io) for Bank of AI*

--- a/energy-bandwidth-skill/SKILL.md
+++ b/energy-bandwidth-skill/SKILL.md
@@ -22,7 +22,7 @@ Manage TRON's unique resource system. Energy is consumed by smart contract execu
 ## Quick Start
 
 ```bash
-cd energy-bandwidth && npm install
+cd energy-bandwidth-skill && npm install
 export TRON_PRIVATE_KEY="<your-private-key>"
 export TRON_NETWORK="mainnet"
 ```

--- a/energy-bandwidth-skill/SKILL.md
+++ b/energy-bandwidth-skill/SKILL.md
@@ -90,12 +90,24 @@ node scripts/delegate.js --undelegate TRecipient 100 ENERGY --dry-run
 
 ---
 
+## Safe Guard — Minimum Reserve Balance
+
+The toolkit enforces a minimum TRX reserve (default: **50 TRX**) to prevent the agent from accidentally bricking an account by staking its entire balance. Both `stake.js` and `delegate.js` will reject any operation that would drop the available TRX balance below this threshold.
+
+The reserve is configured in `resources/resource_config.json` under `safeguard.min_reserve_trx` and can be adjusted per deployment.
+
+> [!IMPORTANT]
+> **Never stake or delegate TRX if doing so would leave the account with less than the configured minimum reserve.** The account must always retain enough TRX to cover transaction fees (bandwidth burn, etc.).
+
+---
+
 ## Security Rules
 
 1. **Never display private keys.**
 2. **Always dry-run before staking/unstaking.** These operations lock TRX.
 3. **Warn about the 14-day unstake cooldown.** Users must understand the lockup.
 4. **Check resource status before operations** to avoid staking more than needed.
+5. **Respect the minimum reserve balance.** Never allow staking or delegation that would leave the account below the configured TRX reserve (default 50 TRX).
 
 ---
 

--- a/energy-bandwidth-skill/package-lock.json
+++ b/energy-bandwidth-skill/package-lock.json
@@ -1,0 +1,553 @@
+{
+  "name": "@bankofai/energy-bandwidth-skill",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@bankofai/energy-bandwidth-skill",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "tronweb": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.4.0",
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ethereum-cryptography": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
+      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.4.2",
+        "@noble/hashes": "1.4.0",
+        "@scure/bip32": "1.4.0",
+        "@scure/bip39": "1.3.0"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.13.5",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.5.tgz",
+      "integrity": "sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/google-protobuf": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tronweb": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tronweb/-/tronweb-6.2.0.tgz",
+      "integrity": "sha512-09kyW6mqiFuSYXkR35ndxCeNF5rW1O18hKAClCLtVHP2xBFPYSGx3lDYC2hRKcuLiq6iLPxOVCrhzoKNGlFuQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "7.26.10",
+        "axios": "1.12.2",
+        "bignumber.js": "9.1.2",
+        "ethereum-cryptography": "2.2.1",
+        "ethers": "6.13.5",
+        "eventemitter3": "5.0.1",
+        "google-protobuf": "3.21.4",
+        "semver": "7.7.1",
+        "validator": "13.15.23"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/validator": {
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/energy-bandwidth-skill/package.json
+++ b/energy-bandwidth-skill/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@bankofai/energy-bandwidth-skill",
+  "version": "1.0.0",
+  "description": "TRON Energy & Bandwidth resource management skill for AI agents",
+  "license": "MIT",
+  "private": true,
+  "engines": { "node": ">=18.0.0" },
+  "dependencies": { "tronweb": "^6.0.0" }
+}

--- a/energy-bandwidth-skill/resources/resource_config.json
+++ b/energy-bandwidth-skill/resources/resource_config.json
@@ -1,0 +1,11 @@
+{
+  "notes": {
+    "energy": "Energy is consumed when executing smart contract calls. Each instruction costs a fixed amount of energy. Obtained by staking TRX.",
+    "bandwidth": "Bandwidth is consumed by the byte-size of each transaction. Every account gets 600 free bandwidth points per day. Obtained by staking TRX.",
+    "freeze_resource_types": ["ENERGY", "BANDWIDTH"],
+    "unstake_cooldown_days": 14,
+    "delegation": "You can delegate energy or bandwidth to another account. Delegated resources can be reclaimed after unlocking.",
+    "energy_price_sun": "The energy price in SUN varies by network parameters. Use getChainParameters to get the current price.",
+    "bandwidth_free_daily": 600
+  }
+}

--- a/energy-bandwidth-skill/resources/resource_config.json
+++ b/energy-bandwidth-skill/resources/resource_config.json
@@ -1,4 +1,8 @@
 {
+  "safeguard": {
+    "min_reserve_trx": 50,
+    "description": "Minimum TRX balance that must remain unstaked to cover basic transaction fees. Staking and delegation operations will be rejected if they would drop the available balance below this threshold."
+  },
   "notes": {
     "energy": "Energy is consumed when executing smart contract calls. Each instruction costs a fixed amount of energy. Obtained by staking TRX.",
     "bandwidth": "Bandwidth is consumed by the byte-size of each transaction. Every account gets 600 free bandwidth points per day. Obtained by staking TRX.",

--- a/energy-bandwidth-skill/scripts/delegate.js
+++ b/energy-bandwidth-skill/scripts/delegate.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+/**
+ * delegate.js — Delegate or undelegate Energy/Bandwidth to another account.
+ *
+ * Usage:
+ *   node delegate.js <toAddress> <amount> <ENERGY|BANDWIDTH> [--dry-run]
+ *   node delegate.js --undelegate <fromAddress> <amount> <ENERGY|BANDWIDTH> [--dry-run]
+ */
+
+const { getTronWeb, toSun, outputJSON, log } = require("./utils");
+
+async function main() {
+  const args = process.argv.slice(2);
+  const tronWeb = getTronWeb();
+  const dryRun = args.includes("--dry-run");
+  const isUndelegate = args[0] === "--undelegate";
+
+  if (isUndelegate) {
+    if (args.length < 4) {
+      console.error("Usage: node delegate.js --undelegate <fromAddress> <amount> <ENERGY|BANDWIDTH> [--dry-run]");
+      process.exit(1);
+    }
+    const receiverAddress = args[1];
+    const amountSun = Number(toSun(args[2]));
+    const resource = args[3].toUpperCase();
+    const result = { action: "undelegate", receiver: receiverAddress, amount_trx: args[2], resource, dry_run: dryRun };
+
+    log(`Undelegating ${args[2]} TRX ${resource} from ${receiverAddress} ...`);
+    if (dryRun) { result.status = "dry_run"; outputJSON(result); return; }
+
+    try {
+      const tx = await tronWeb.transactionBuilder.undelegateResource(amountSun, receiverAddress, resource);
+      const signed = await tronWeb.trx.sign(tx);
+      const broadcast = await tronWeb.trx.sendRawTransaction(signed);
+      result.status = broadcast.result ? "submitted" : "failed";
+      result.tx_id = broadcast.txid;
+    } catch (e) { result.status = "failed"; result.error = e.message || String(e); }
+    outputJSON(result);
+    return;
+  }
+
+  if (args.length < 3) {
+    console.error("Usage: node delegate.js <toAddress> <amount> <ENERGY|BANDWIDTH> [--dry-run]");
+    process.exit(1);
+  }
+
+  const toAddress = args[0];
+  const amountSun = Number(toSun(args[1]));
+  const resource = args[2].toUpperCase();
+  const result = { action: "delegate", to: toAddress, amount_trx: args[1], resource, dry_run: dryRun };
+
+  log(`Delegating ${args[1]} TRX ${resource} to ${toAddress} ...`);
+  if (dryRun) { result.status = "dry_run"; outputJSON(result); return; }
+
+  try {
+    const tx = await tronWeb.transactionBuilder.delegateResource(amountSun, toAddress, resource);
+    const signed = await tronWeb.trx.sign(tx);
+    const broadcast = await tronWeb.trx.sendRawTransaction(signed);
+    result.status = broadcast.result ? "submitted" : "failed";
+    result.tx_id = broadcast.txid;
+  } catch (e) { result.status = "failed"; result.error = e.message || String(e); }
+  outputJSON(result);
+}
+
+main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });

--- a/energy-bandwidth-skill/scripts/delegate.js
+++ b/energy-bandwidth-skill/scripts/delegate.js
@@ -8,7 +8,7 @@
  *   node delegate.js --undelegate <fromAddress> <amount> <ENERGY|BANDWIDTH> [--dry-run]
  */
 
-const { getTronWeb, toSun, outputJSON, log } = require("./utils");
+const { getTronWeb, toSun, outputJSON, log, checkReserve } = require("./utils");
 
 async function main() {
   const args = process.argv.slice(2);
@@ -49,6 +49,9 @@ async function main() {
   const amountSun = Number(toSun(args[1]));
   const resource = args[2].toUpperCase();
   const result = { action: "delegate", to: toAddress, amount_trx: args[1], resource, dry_run: dryRun };
+
+  const balance = await tronWeb.trx.getBalance(tronWeb.defaultAddress.base58);
+  checkReserve(balance, amountSun);
 
   log(`Delegating ${args[1]} TRX ${resource} to ${toAddress} ...`);
   if (dryRun) { result.status = "dry_run"; outputJSON(result); return; }

--- a/energy-bandwidth-skill/scripts/estimate.js
+++ b/energy-bandwidth-skill/scripts/estimate.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+/**
+ * estimate.js — Estimate energy cost for a smart contract call.
+ *
+ * Usage:
+ *   node estimate.js <contractAddress> <functionSelector> [param1,param2,...] [callValue]
+ *
+ * Example:
+ *   node estimate.js TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t "transfer(address,uint256)" "TRecipient,1000000"
+ */
+
+const { getTronWeb, outputJSON, log } = require("./utils");
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error("Usage: node estimate.js <contract> <functionSelector> [params] [callValue]");
+    process.exit(1);
+  }
+
+  const tronWeb = getTronWeb();
+  const contractAddress = args[0];
+  const functionSelector = args[1];
+  const parameters = args[2] ? args[2].split(",").map((p) => p.trim()) : [];
+  const callValue = args[3] ? Number(args[3]) : 0;
+  const ownerAddress = tronWeb.defaultAddress.base58;
+
+  log(`Estimating energy for ${functionSelector} on ${contractAddress} ...`);
+
+  try {
+    const tx = await tronWeb.transactionBuilder.triggerConstantContract(
+      contractAddress,
+      functionSelector,
+      {},
+      parameters.map((p, i) => ({ type: "auto", value: p })),
+      ownerAddress
+    );
+
+    const energyUsed = tx.energy_used || tx.energy_penalty || 0;
+    outputJSON({
+      contract: contractAddress,
+      function: functionSelector,
+      estimated_energy: energyUsed,
+      result: tx.constant_result ? tx.constant_result[0] : null,
+    });
+  } catch (e) {
+    outputJSON({
+      contract: contractAddress,
+      function: functionSelector,
+      error: e.message || String(e),
+      note: "Estimation may fail for state-changing functions. Use triggerSmartContract for accurate estimates.",
+    });
+  }
+}
+
+main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });

--- a/energy-bandwidth-skill/scripts/estimate.js
+++ b/energy-bandwidth-skill/scripts/estimate.js
@@ -22,9 +22,20 @@ async function main() {
   const tronWeb = getTronWeb();
   const contractAddress = args[0];
   const functionSelector = args[1];
-  const parameters = args[2] ? args[2].split(",").map((p) => p.trim()) : [];
+  const paramValues = args[2] ? args[2].split(",").map((p) => p.trim()) : [];
   const callValue = args[3] ? Number(args[3]) : 0;
   const ownerAddress = tronWeb.defaultAddress.base58;
+
+  // Extract parameter types from function selector, e.g. "transfer(address,uint256)" -> ["address","uint256"]
+  const typeMatch = functionSelector.match(/\(([^)]*)\)/);
+  const paramTypes = typeMatch && typeMatch[1] ? typeMatch[1].split(",").map((t) => t.trim()) : [];
+
+  if (paramValues.length !== paramTypes.length) {
+    outputJSON({ error: `Parameter count mismatch: selector has ${paramTypes.length} params but ${paramValues.length} values provided.` });
+    process.exit(1);
+  }
+
+  const parameters = paramValues.map((value, i) => ({ type: paramTypes[i], value }));
 
   log(`Estimating energy for ${functionSelector} on ${contractAddress} ...`);
 
@@ -32,8 +43,8 @@ async function main() {
     const tx = await tronWeb.transactionBuilder.triggerConstantContract(
       contractAddress,
       functionSelector,
-      {},
-      parameters.map((p, i) => ({ type: "auto", value: p })),
+      { callValue },
+      parameters,
       ownerAddress
     );
 

--- a/energy-bandwidth-skill/scripts/stake.js
+++ b/energy-bandwidth-skill/scripts/stake.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+/**
+ * stake.js — Stake TRX for Energy or Bandwidth (Freeze Balance V2).
+ *
+ * Usage:
+ *   node stake.js <amount> <ENERGY|BANDWIDTH> [--dry-run]
+ */
+
+const { getTronWeb, toSun, fromSun, outputJSON, log } = require("./utils");
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) { console.error("Usage: node stake.js <amount> <ENERGY|BANDWIDTH> [--dry-run]"); process.exit(1); }
+
+  const tronWeb = getTronWeb();
+  const amountTrx = args[0];
+  const resource = args[1].toUpperCase();
+  const dryRun = args.includes("--dry-run");
+
+  if (!["ENERGY", "BANDWIDTH"].includes(resource)) {
+    outputJSON({ error: "Resource must be ENERGY or BANDWIDTH" });
+    process.exit(1);
+  }
+
+  const amountSun = Number(toSun(amountTrx));
+  const balance = await tronWeb.trx.getBalance(tronWeb.defaultAddress.base58);
+
+  if (amountSun > balance) {
+    outputJSON({ error: `Insufficient TRX. Have ${fromSun(balance)}, need ${amountTrx}` });
+    process.exit(1);
+  }
+
+  const result = {
+    action: "stake",
+    amount_trx: amountTrx,
+    resource,
+    dry_run: dryRun,
+  };
+
+  log(`Staking ${amountTrx} TRX for ${resource} ...`);
+
+  if (dryRun) { result.status = "dry_run"; outputJSON(result); return; }
+
+  try {
+    const tx = await tronWeb.transactionBuilder.freezeBalanceV2(amountSun, resource);
+    const signed = await tronWeb.trx.sign(tx);
+    const broadcast = await tronWeb.trx.sendRawTransaction(signed);
+    result.status = broadcast.result ? "submitted" : "failed";
+    result.tx_id = broadcast.txid;
+    log(`Transaction: ${broadcast.txid}`);
+  } catch (e) {
+    result.status = "failed";
+    result.error = e.message || String(e);
+  }
+
+  outputJSON(result);
+}
+
+main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });

--- a/energy-bandwidth-skill/scripts/stake.js
+++ b/energy-bandwidth-skill/scripts/stake.js
@@ -7,7 +7,7 @@
  *   node stake.js <amount> <ENERGY|BANDWIDTH> [--dry-run]
  */
 
-const { getTronWeb, toSun, fromSun, outputJSON, log } = require("./utils");
+const { getTronWeb, toSun, fromSun, outputJSON, log, checkReserve } = require("./utils");
 
 async function main() {
   const args = process.argv.slice(2);
@@ -30,6 +30,8 @@ async function main() {
     outputJSON({ error: `Insufficient TRX. Have ${fromSun(balance)}, need ${amountTrx}` });
     process.exit(1);
   }
+
+  checkReserve(balance, amountSun);
 
   const result = {
     action: "stake",

--- a/energy-bandwidth-skill/scripts/status.js
+++ b/energy-bandwidth-skill/scripts/status.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+/**
+ * status.js — Check current energy, bandwidth, and frozen TRX balances.
+ *
+ * Usage:
+ *   node status.js [walletAddress]
+ */
+
+const { getTronWeb, fromSun, outputJSON, log } = require("./utils");
+
+async function main() {
+  const tronWeb = getTronWeb();
+  const address = process.argv[2] || tronWeb.defaultAddress.base58;
+  log(`Checking resources for ${address} ...`);
+
+  const [resources, account, trxBalance] = await Promise.all([
+    tronWeb.trx.getAccountResources(address),
+    tronWeb.trx.getAccount(address),
+    tronWeb.trx.getBalance(address),
+  ]);
+
+  const energyLimit = resources.EnergyLimit || 0;
+  const energyUsed = resources.EnergyUsed || 0;
+  const bwLimit = (resources.freeNetLimit || 0) + (resources.NetLimit || 0);
+  const bwUsed = (resources.freeNetUsed || 0) + (resources.NetUsed || 0);
+
+  const frozenV2 = account.frozenV2 || [];
+  const frozenEnergy = frozenV2.find((f) => f.type === "ENERGY") || {};
+  const frozenBandwidth = frozenV2.find((f) => !f.type || f.type === "BANDWIDTH") || {};
+
+  const unfrozenV2 = account.unfrozenV2 || [];
+
+  outputJSON({
+    wallet: address,
+    trx_balance: fromSun(trxBalance),
+    energy: {
+      available: energyLimit - energyUsed,
+      limit: energyLimit,
+      used: energyUsed,
+      frozen_trx: fromSun(frozenEnergy.amount || 0),
+    },
+    bandwidth: {
+      available: bwLimit - bwUsed,
+      limit: bwLimit,
+      used: bwUsed,
+      free_limit: resources.freeNetLimit || 0,
+      frozen_trx: fromSun(frozenBandwidth.amount || 0),
+    },
+    pending_unstakes: unfrozenV2.map((u) => ({
+      amount_trx: fromSun(u.unfreeze_amount || 0),
+      expire_time: u.unfreeze_expire_time ? new Date(u.unfreeze_expire_time).toISOString() : null,
+      type: u.type || "BANDWIDTH",
+    })),
+  });
+}
+
+main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });

--- a/energy-bandwidth-skill/scripts/status.js
+++ b/energy-bandwidth-skill/scripts/status.js
@@ -7,11 +7,12 @@
  *   node status.js [walletAddress]
  */
 
-const { getTronWeb, fromSun, outputJSON, log } = require("./utils");
+const { getTronWeb, getTronWebReadOnly, fromSun, outputJSON, log } = require("./utils");
 
 async function main() {
-  const tronWeb = getTronWeb();
-  const address = process.argv[2] || tronWeb.defaultAddress.base58;
+  const addressArg = process.argv[2];
+  const tronWeb = addressArg ? getTronWebReadOnly() : getTronWeb();
+  const address = addressArg || tronWeb.defaultAddress.base58;
   log(`Checking resources for ${address} ...`);
 
   const [resources, account, trxBalance] = await Promise.all([

--- a/energy-bandwidth-skill/scripts/unstake.js
+++ b/energy-bandwidth-skill/scripts/unstake.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+/**
+ * unstake.js — Begin TRX unstake (14-day cooldown) or withdraw expired unstakes.
+ *
+ * Usage:
+ *   node unstake.js <amount> <ENERGY|BANDWIDTH> [--dry-run]    # Begin cooldown
+ *   node unstake.js --withdraw [--dry-run]                      # Claim expired
+ */
+
+const { getTronWeb, toSun, outputJSON, log } = require("./utils");
+
+async function main() {
+  const args = process.argv.slice(2);
+  const tronWeb = getTronWeb();
+  const dryRun = args.includes("--dry-run");
+  const isWithdraw = args.includes("--withdraw");
+
+  if (isWithdraw) {
+    log("Withdrawing expired unstakes ...");
+    const result = { action: "withdraw_unstake", dry_run: dryRun };
+
+    if (dryRun) { result.status = "dry_run"; outputJSON(result); return; }
+
+    try {
+      const tx = await tronWeb.transactionBuilder.withdrawExpireUnfreeze();
+      const signed = await tronWeb.trx.sign(tx);
+      const broadcast = await tronWeb.trx.sendRawTransaction(signed);
+      result.status = broadcast.result ? "submitted" : "failed";
+      result.tx_id = broadcast.txid;
+    } catch (e) {
+      result.status = "failed";
+      result.error = e.message || String(e);
+    }
+    outputJSON(result);
+    return;
+  }
+
+  if (args.length < 2) {
+    console.error("Usage: node unstake.js <amount> <ENERGY|BANDWIDTH> [--dry-run]  OR  --withdraw [--dry-run]");
+    process.exit(1);
+  }
+
+  const amountTrx = args[0];
+  const resource = args[1].toUpperCase();
+  const amountSun = Number(toSun(amountTrx));
+
+  if (!["ENERGY", "BANDWIDTH"].includes(resource)) {
+    outputJSON({ error: "Resource must be ENERGY or BANDWIDTH" });
+    process.exit(1);
+  }
+
+  const result = { action: "begin_unstake", amount_trx: amountTrx, resource, cooldown_days: 14, dry_run: dryRun };
+  log(`Beginning unstake of ${amountTrx} TRX from ${resource} (14-day cooldown) ...`);
+
+  if (dryRun) { result.status = "dry_run"; outputJSON(result); return; }
+
+  try {
+    const tx = await tronWeb.transactionBuilder.unfreezeBalanceV2(amountSun, resource);
+    const signed = await tronWeb.trx.sign(tx);
+    const broadcast = await tronWeb.trx.sendRawTransaction(signed);
+    result.status = broadcast.result ? "submitted" : "failed";
+    result.tx_id = broadcast.txid;
+  } catch (e) {
+    result.status = "failed";
+    result.error = e.message || String(e);
+  }
+
+  outputJSON(result);
+}
+
+main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });

--- a/energy-bandwidth-skill/scripts/utils.js
+++ b/energy-bandwidth-skill/scripts/utils.js
@@ -1,0 +1,44 @@
+/**
+ * Shared utilities for Energy & Bandwidth skill scripts.
+ */
+
+const { TronWeb } = require("tronweb");
+const path = require("path");
+const fs = require("fs");
+
+const CONFIG = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "resources", "resource_config.json"), "utf-8")
+);
+
+const TRX_DECIMALS = 6;
+
+function getTronWeb() {
+  const network = (process.env.TRON_NETWORK || "mainnet").toLowerCase();
+  const hosts = { mainnet: "https://api.trongrid.io", nile: "https://nile.trongrid.io", shasta: "https://api.shasta.trongrid.io" };
+  const fullHost = hosts[network];
+  if (!fullHost) throw new Error(`Unknown network "${network}".`);
+  const privateKey = process.env.TRON_PRIVATE_KEY;
+  if (!privateKey) throw new Error("TRON_PRIVATE_KEY environment variable is required");
+  const opts = { fullHost, privateKey };
+  if (process.env.TRONGRID_API_KEY) opts.headers = { "TRON-PRO-API-KEY": process.env.TRONGRID_API_KEY };
+  return new TronWeb(opts);
+}
+
+function toSun(amount) {
+  const parts = String(amount).split(".");
+  const whole = parts[0] || "0";
+  const frac = (parts[1] || "").slice(0, TRX_DECIMALS).padEnd(TRX_DECIMALS, "0");
+  return BigInt(whole) * BigInt(10 ** TRX_DECIMALS) + BigInt(frac);
+}
+
+function fromSun(raw) {
+  const str = String(raw).padStart(TRX_DECIMALS + 1, "0");
+  const whole = str.slice(0, str.length - TRX_DECIMALS) || "0";
+  const frac = str.slice(str.length - TRX_DECIMALS).replace(/0+$/, "");
+  return frac ? `${whole}.${frac}` : whole;
+}
+
+function outputJSON(data) { process.stdout.write(JSON.stringify(data, null, 2) + "\n"); }
+function log(msg) { process.stderr.write(msg + "\n"); }
+
+module.exports = { CONFIG, TRX_DECIMALS, getTronWeb, toSun, fromSun, outputJSON, log };

--- a/energy-bandwidth-skill/scripts/utils.js
+++ b/energy-bandwidth-skill/scripts/utils.js
@@ -11,6 +11,7 @@ const CONFIG = JSON.parse(
 );
 
 const TRX_DECIMALS = 6;
+const MIN_RESERVE_SUN = BigInt(CONFIG.safeguard.min_reserve_trx) * BigInt(10 ** TRX_DECIMALS);
 
 function getTronWeb() {
   const network = (process.env.TRON_NETWORK || "mainnet").toLowerCase();
@@ -41,4 +42,15 @@ function fromSun(raw) {
 function outputJSON(data) { process.stdout.write(JSON.stringify(data, null, 2) + "\n"); }
 function log(msg) { process.stderr.write(msg + "\n"); }
 
-module.exports = { CONFIG, TRX_DECIMALS, getTronWeb, toSun, fromSun, outputJSON, log };
+function checkReserve(balanceSun, spendSun) {
+  const remaining = BigInt(balanceSun) - BigInt(spendSun);
+  if (remaining < MIN_RESERVE_SUN) {
+    const reserveTrx = CONFIG.safeguard.min_reserve_trx;
+    outputJSON({
+      error: `Safe guard: this operation would leave only ${fromSun(remaining)} TRX, which is below the minimum reserve of ${reserveTrx} TRX. Reduce the amount or top up your account.`,
+    });
+    process.exit(1);
+  }
+}
+
+module.exports = { CONFIG, TRX_DECIMALS, MIN_RESERVE_SUN, getTronWeb, toSun, fromSun, outputJSON, log, checkReserve };

--- a/energy-bandwidth-skill/scripts/utils.js
+++ b/energy-bandwidth-skill/scripts/utils.js
@@ -25,6 +25,21 @@ function getTronWeb() {
   return new TronWeb(opts);
 }
 
+function getTronWebReadOnly() {
+  const network = (process.env.TRON_NETWORK || "mainnet").toLowerCase();
+  const hosts = { mainnet: "https://api.trongrid.io", nile: "https://nile.trongrid.io", shasta: "https://api.shasta.trongrid.io" };
+  const fullHost = hosts[network];
+  if (!fullHost) throw new Error(`Unknown network "${network}".`);
+  const opts = { fullHost };
+  if (process.env.TRONGRID_API_KEY) opts.headers = { "TRON-PRO-API-KEY": process.env.TRONGRID_API_KEY };
+  const tw = new TronWeb(opts);
+  tw.defaultAddress = {
+    hex: "410000000000000000000000000000000000000000",
+    base58: "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb",
+  };
+  return tw;
+}
+
 function toSun(amount) {
   const parts = String(amount).split(".");
   const whole = parts[0] || "0";
@@ -53,4 +68,4 @@ function checkReserve(balanceSun, spendSun) {
   }
 }
 
-module.exports = { CONFIG, TRX_DECIMALS, MIN_RESERVE_SUN, getTronWeb, toSun, fromSun, outputJSON, log, checkReserve };
+module.exports = { CONFIG, TRX_DECIMALS, MIN_RESERVE_SUN, getTronWeb, getTronWebReadOnly, toSun, fromSun, outputJSON, log, checkReserve };


### PR DESCRIPTION
## Summary
- Adds `energy-bandwidth-skill` for monitoring and managing TRON Energy and Bandwidth resources
- Check current resource status and usage
- Estimate energy/bandwidth costs for transactions
- Stake TRX for resources, unstake when no longer needed
- Delegate resources to other accounts

## Scripts
- `status.js` — View current resource balances and usage
- `estimate.js` — Estimate energy/bandwidth costs
- `stake.js` — Stake TRX for energy or bandwidth
- `unstake.js` — Unstake TRX
- `delegate.js` — Delegate resources to other accounts

Source: https://github.com/M2M-TRC8004-Registry/energy-bandwidth-skill