### PR TITLE
Add JustLend DAO Lending skill

### DIFF
--- a/justlend-skill/.gitignore
+++ b/justlend-skill/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/justlend-skill/README.md
+++ b/justlend-skill/README.md
@@ -1,0 +1,28 @@
+# JustLend DAO
+
+> Supply and borrow assets on TRON's largest lending protocol.
+
+## Scripts
+
+- `markets.js` — List markets with supply/borrow APY rates
+- `position.js` — Check supplied/borrowed amounts and health
+- `supply.js` — Supply assets to earn interest
+- `withdraw.js` — Withdraw supplied assets
+- `borrow.js` — Borrow against collateral
+- `repay.js` — Repay borrowed assets
+
+## Quick Start
+
+```bash
+cd justlend && npm install
+export TRON_PRIVATE_KEY="<key>"
+
+node scripts/markets.js
+node scripts/supply.js TRX 100 --dry-run
+node scripts/position.js
+```
+
+## Dependencies
+
+- Node.js 18+
+- [tronweb](https://www.npmjs.com/package/tronweb) ^6.0.0

--- a/justlend-skill/README.md
+++ b/justlend-skill/README.md
@@ -14,7 +14,7 @@
 ## Quick Start
 
 ```bash
-cd justlend && npm install
+cd justlend-skill && npm install
 export TRON_PRIVATE_KEY="<key>"
 
 node scripts/markets.js

--- a/justlend-skill/README.md
+++ b/justlend-skill/README.md
@@ -5,10 +5,10 @@
 ## Scripts
 
 - `markets.js` — List markets with supply/borrow APY rates
-- `position.js` — Check supplied/borrowed amounts and health
+- `position.js` — Check supplied/borrowed amounts, health factor, and liquidation risk
 - `supply.js` — Supply assets to earn interest
 - `withdraw.js` — Withdraw supplied assets
-- `borrow.js` — Borrow against collateral
+- `borrow.js` — Borrow against collateral (with health factor safeguard)
 - `repay.js` — Repay borrowed assets
 
 ## Quick Start
@@ -21,6 +21,16 @@ node scripts/markets.js
 node scripts/supply.js TRX 100 --dry-run
 node scripts/position.js
 ```
+
+## Health Factor Safeguard
+
+Before every borrow, `borrow.js` estimates the post-borrow health factor using on-chain oracle prices. If the health factor would drop below the configured minimum (default: **1.2**), the borrow is blocked. Thresholds are configurable in `resources/justlend_contracts.json`.
+
+| Health Factor | Result |
+|---|---|
+| ≥ 1.5 | Safe — no warnings |
+| 1.2 – 1.5 | Warning emitted |
+| < 1.2 | Borrow blocked |
 
 ## Dependencies
 

--- a/justlend-skill/README.md
+++ b/justlend-skill/README.md
@@ -11,6 +11,10 @@
 - `borrow.js` — Borrow against collateral (with health factor safeguard)
 - `repay.js` — Repay borrowed assets
 
+## Network Support
+
+**Mainnet only.** JustLend contract addresses and market configurations are defined for TRON Mainnet. Nile and Shasta testnets are not supported.
+
 ## Quick Start
 
 ```bash

--- a/justlend-skill/SKILL.md
+++ b/justlend-skill/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: JustLend DAO
+description: Supply and borrow assets on JustLend, TRON's largest lending protocol.
+version: 1.0.0
+dependencies:
+  - node >= 18.0.0
+  - tronweb
+tags:
+  - defi
+  - lending
+  - tron
+  - justlend
+  - yield
+---
+
+# JustLend DAO
+
+Supply assets to earn interest and borrow against collateral on **JustLend DAO** — TRON's largest lending protocol ($5.95B TVL). Supports TRX, USDT, USDC, USDD, SUN, BTT, and JST markets.
+
+---
+
+## Quick Start
+
+```bash
+cd justlend && npm install
+export TRON_PRIVATE_KEY="<your-private-key>"
+export TRON_NETWORK="mainnet"
+```
+
+> [!CAUTION]
+> **Never display or log the private key.**
+
+---
+
+## Available Scripts
+
+### 1. `markets.js` — List Markets with APY
+
+```bash
+node scripts/markets.js
+```
+
+**Output:** `markets[]` (symbol, jToken, supply_apy, borrow_apy)
+
+### 2. `position.js` — Check Positions
+
+```bash
+node scripts/position.js
+node scripts/position.js TWalletAddress
+```
+
+**Output:** `liquidity` (excess_liquidity_usd, shortfall_usd), `positions[]` (supplied, borrowed)
+
+### 3. `supply.js` — Supply Assets
+
+```bash
+node scripts/supply.js TRX 100 --dry-run
+node scripts/supply.js USDT 50
+```
+
+> [!NOTE]
+> For TRC20 tokens, the script auto-handles approval. For TRX, it uses the native payable mint.
+
+### 4. `withdraw.js` — Withdraw Supplied Assets
+
+```bash
+node scripts/withdraw.js USDT 25 --dry-run
+node scripts/withdraw.js TRX all
+```
+
+### 5. `borrow.js` — Borrow Against Collateral
+
+```bash
+node scripts/borrow.js USDT 100 --dry-run
+node scripts/borrow.js USDT 100
+```
+
+> [!WARNING]
+> Borrowing creates a debt position. If your collateral value drops below the required threshold, your position may be **liquidated**. Always check `position.js` for health before borrowing.
+
+### 6. `repay.js` — Repay Borrowed Assets
+
+```bash
+node scripts/repay.js USDT 50 --dry-run
+node scripts/repay.js USDT all
+```
+
+---
+
+## Usage Patterns
+
+### Earn Yield (Supply Only)
+
+```bash
+node scripts/markets.js                     # Check APYs
+node scripts/supply.js USDT 1000 --dry-run   # Estimate
+node scripts/supply.js USDT 1000             # Execute
+node scripts/position.js                     # Verify
+```
+
+### Borrow Against Collateral
+
+```bash
+node scripts/supply.js TRX 5000             # Supply collateral
+node scripts/position.js                     # Check liquidity
+node scripts/borrow.js USDT 100 --dry-run    # Estimate borrow
+node scripts/borrow.js USDT 100              # Execute
+```
+
+### Repay and Withdraw
+
+```bash
+node scripts/repay.js USDT all               # Repay full debt
+node scripts/withdraw.js TRX all             # Withdraw collateral
+```
+
+---
+
+## Supported Markets
+
+| Asset | jToken | Decimals |
+|---|---|---|
+| TRX | `TLeEu311Vrv2asMEqrEAFRyAZGU83RB27h` | 6 |
+| USDT | `TXJgMRrQHTzLMcKfSEZ4LRCWZkBq4iZ5EL` | 6 |
+| USDC | `TX7kybeP6UwTBRHLNPYmswFESHfyjm9bAS` | 6 |
+| USDD | `TX1x3z8wVJiSdVkFR2WdKtrqEQoRNYHoEW` | 18 |
+| SUN | `TPYfcPk9T5C5fqwzAGdzYDCiWKJpGSoFma` | 18 |
+| BTT | `TGkfRFBa3FKQP3YjibZL4kR1DuPcGS1eiS` | 18 |
+| JST | `TRgRMmyNoelaqA7Md23hLKfnr1FEQoSHcH` | 18 |
+
+---
+
+## Security Rules
+
+1. **Never display private keys.**
+2. **Always dry-run before supplying or borrowing.**
+3. **Check position health before borrowing.** Monitor `excess_liquidity_usd` — if it reaches 0, liquidation risk is imminent.
+4. **Repay borrows before withdrawing collateral** to avoid liquidation.
+5. **Warn about liquidation risk** whenever a user borrows or the health factor is low.
+
+---
+
+## Common Issues
+
+| Problem | Solution |
+|---|---|
+| `Unknown asset` | Use symbol from supported markets table |
+| `No jTokens to redeem` | Nothing is supplied in that market |
+| Supply fails for TRC20 | Approval may have failed — check allowance |
+| Borrow fails | Insufficient collateral — supply more first |
+| `redeemUnderlying` fails | Trying to withdraw more than supplied |
+
+---
+
+*Version 1.0.0 — Created by [M2M Agent Registry](https://m2mregistry.io) for Bank of AI*

--- a/justlend-skill/SKILL.md
+++ b/justlend-skill/SKILL.md
@@ -30,6 +30,9 @@ export TRON_NETWORK="mainnet"
 > [!CAUTION]
 > **Never display or log the private key.**
 
+> [!IMPORTANT]
+> **This skill is mainnet-only.** JustLend contract addresses and market configurations are defined for TRON Mainnet only. Nile and Shasta testnets are not supported.
+
 ---
 
 ## Available Scripts

--- a/justlend-skill/SKILL.md
+++ b/justlend-skill/SKILL.md
@@ -15,14 +15,14 @@ tags:
 
 # JustLend DAO
 
-Supply assets to earn interest and borrow against collateral on **JustLend DAO** — TRON's largest lending protocol ($5.95B TVL). Supports TRX, USDT, USDC, USDD, SUN, BTT, and JST markets.
+Supply assets to earn interest and borrow against collateral on **JustLend DAO** — TRON's largest lending protocol ($5.95B TVL). Supports TRX, USDT, USDC, USDD, SUN, BTT, JST, WIN, and BTC markets.
 
 ---
 
 ## Quick Start
 
 ```bash
-cd justlend && npm install
+cd justlend-skill && npm install
 export TRON_PRIVATE_KEY="<your-private-key>"
 export TRON_NETWORK="mainnet"
 ```
@@ -120,13 +120,15 @@ node scripts/withdraw.js TRX all             # Withdraw collateral
 
 | Asset | jToken | Decimals |
 |---|---|---|
-| TRX | `TLeEu311Vrv2asMEqrEAFRyAZGU83RB27h` | 6 |
-| USDT | `TXJgMRrQHTzLMcKfSEZ4LRCWZkBq4iZ5EL` | 6 |
-| USDC | `TX7kybeP6UwTBRHLNPYmswFESHfyjm9bAS` | 6 |
-| USDD | `TX1x3z8wVJiSdVkFR2WdKtrqEQoRNYHoEW` | 18 |
-| SUN | `TPYfcPk9T5C5fqwzAGdzYDCiWKJpGSoFma` | 18 |
-| BTT | `TGkfRFBa3FKQP3YjibZL4kR1DuPcGS1eiS` | 18 |
-| JST | `TRgRMmyNoelaqA7Md23hLKfnr1FEQoSHcH` | 18 |
+| TRX | `TE2RzoSV3wFK99w6J9UnnZ4vLfXYoxvRwP` | 6 |
+| USDT | `TXJgMdjVX5dKiQaUi9QobwNxtSQaFqccvd` | 6 |
+| USDC | `TNSBA6KvSvMoTqQcEgpVK7VhHT3z7wifxy` | 6 |
+| USDD | `TKFRELGGoRgiayhwJTNNLqCNjFoLBh3Mnf` | 18 |
+| SUN | `TGBr8uh9jBVHJhhkwSJvQN2ZAKzVkxDmno` | 18 |
+| BTT | `TUaUHU9Dy8x5yNi1pKnFYqHWojot61Jfto` | 18 |
+| JST | `TWQhCXaWz4eHK4Kd1ErSDHjMFPoPc9czts` | 18 |
+| WIN | `TRg6MnpsFXc82ymUPgf5qbj59ibxiEDWvv` | 6 |
+| BTC | `TLeEu311Cbw63BcmMHDgDLu7fnk9fqGcqT` | 8 |
 
 ---
 

--- a/justlend-skill/SKILL.md
+++ b/justlend-skill/SKILL.md
@@ -42,14 +42,14 @@ node scripts/markets.js
 
 **Output:** `markets[]` (symbol, jToken, supply_apy, borrow_apy)
 
-### 2. `position.js` — Check Positions
+### 2. `position.js` — Check Positions & Health Factor
 
 ```bash
 node scripts/position.js
 node scripts/position.js TWalletAddress
 ```
 
-**Output:** `liquidity` (excess_liquidity_usd, shortfall_usd), `positions[]` (supplied, borrowed)
+**Output:** `liquidity` (excess_liquidity_usd, shortfall_usd), `health_factor` (health_factor, total_borrow_usd), `positions[]` (supplied, borrowed)
 
 ### 3. `supply.js` — Supply Assets
 
@@ -76,7 +76,7 @@ node scripts/borrow.js USDT 100
 ```
 
 > [!WARNING]
-> Borrowing creates a debt position. If your collateral value drops below the required threshold, your position may be **liquidated**. Always check `position.js` for health before borrowing.
+> Borrowing creates a debt position. If your collateral value drops below the required threshold, your position may be **liquidated**. The script automatically estimates the post-borrow health factor and blocks the transaction if it would fall below the safety threshold (default: 1.2).
 
 ### 6. `repay.js` — Repay Borrowed Assets
 
@@ -102,9 +102,9 @@ node scripts/position.js                     # Verify
 
 ```bash
 node scripts/supply.js TRX 5000             # Supply collateral
-node scripts/position.js                     # Check liquidity
-node scripts/borrow.js USDT 100 --dry-run    # Estimate borrow
-node scripts/borrow.js USDT 100              # Execute
+node scripts/position.js                     # Check liquidity & health factor
+node scripts/borrow.js USDT 100 --dry-run    # Estimate borrow (includes health factor projection)
+node scripts/borrow.js USDT 100              # Execute (blocked if health factor < 1.2)
 ```
 
 ### Repay and Withdraw
@@ -130,13 +130,66 @@ node scripts/withdraw.js TRX all             # Withdraw collateral
 
 ---
 
+## Health Factor Monitoring
+
+The **health factor** measures how close a position is to liquidation:
+
+```
+Health Factor = Total Collateral Value (USD, adjusted by collateral factors) / Total Borrow Value (USD)
+```
+
+| Health Factor | Status | Action |
+|---|---|---|
+| > 1.5 | Safe | No action needed |
+| 1.2 – 1.5 | Warning | Script logs a warning; consider reducing borrow or adding collateral |
+| < 1.2 | Blocked | `borrow.js` refuses to execute — too close to liquidation |
+| < 1.0 | Liquidatable | Position can be liquidated by anyone |
+
+### Configuration
+
+Thresholds are defined in `resources/justlend_contracts.json` under the `health_factor` key:
+
+| Parameter | Default | Description |
+|---|---|---|
+| `min_threshold` | `1.2` | Borrows below this are blocked |
+| `warn_threshold` | `1.5` | Borrows below this emit a warning |
+
+### How It Works
+
+1. **Before every borrow**, `borrow.js` calls `estimateHealthFactorAfterBorrow()` which:
+   - Reads current account liquidity from the Comptroller (`getAccountLiquidity`)
+   - Fetches the oracle price for the borrow asset (`getUnderlyingPrice`)
+   - Computes total existing borrows in USD across all markets
+   - Calculates the projected health factor after adding the new borrow
+   - Blocks the transaction if the result is below `min_threshold`
+
+2. **`position.js`** includes the current health factor in its output via `getHealthFactor()`, with warnings when it drops below safe levels.
+
+3. **Dry-run mode** also estimates the health factor, so agents can preview the impact before committing.
+
+### Example: Borrow Blocked by Health Factor
+
+```bash
+$ node scripts/borrow.js USDT 5000 --dry-run
+```
+```json
+{
+  "error": "Health factor safeguard: Borrowing 5000 USDT would result in a health factor of 1.08, which is below the minimum threshold of 1.2. Reduce the borrow amount or supply more collateral.",
+  "estimated_health_factor": 1.08,
+  "min_threshold": 1.2
+}
+```
+
+---
+
 ## Security Rules
 
 1. **Never display private keys.**
 2. **Always dry-run before supplying or borrowing.**
-3. **Check position health before borrowing.** Monitor `excess_liquidity_usd` — if it reaches 0, liquidation risk is imminent.
+3. **Check position health before borrowing.** Monitor `health_factor` in `position.js` output — if it approaches 1.0, liquidation is imminent.
 4. **Repay borrows before withdrawing collateral** to avoid liquidation.
 5. **Warn about liquidation risk** whenever a user borrows or the health factor is low.
+6. **Never bypass the health factor safeguard.** If `borrow.js` blocks a transaction due to low health factor, do not attempt to call the contract directly.
 
 ---
 

--- a/justlend-skill/package-lock.json
+++ b/justlend-skill/package-lock.json
@@ -1,0 +1,553 @@
+{
+  "name": "@bankofai/justlend-skill",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@bankofai/justlend-skill",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "tronweb": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.4.0",
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ethereum-cryptography": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
+      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.4.2",
+        "@noble/hashes": "1.4.0",
+        "@scure/bip32": "1.4.0",
+        "@scure/bip39": "1.3.0"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.13.5",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.5.tgz",
+      "integrity": "sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/google-protobuf": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tronweb": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tronweb/-/tronweb-6.2.0.tgz",
+      "integrity": "sha512-09kyW6mqiFuSYXkR35ndxCeNF5rW1O18hKAClCLtVHP2xBFPYSGx3lDYC2hRKcuLiq6iLPxOVCrhzoKNGlFuQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "7.26.10",
+        "axios": "1.12.2",
+        "bignumber.js": "9.1.2",
+        "ethereum-cryptography": "2.2.1",
+        "ethers": "6.13.5",
+        "eventemitter3": "5.0.1",
+        "google-protobuf": "3.21.4",
+        "semver": "7.7.1",
+        "validator": "13.15.23"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/validator": {
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/justlend-skill/package.json
+++ b/justlend-skill/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@bankofai/justlend-skill",
+  "version": "1.0.0",
+  "description": "JustLend DAO lending protocol skill for AI agents on TRON",
+  "license": "MIT",
+  "private": true,
+  "engines": { "node": ">=18.0.0" },
+  "dependencies": { "tronweb": "^6.0.0" }
+}

--- a/justlend-skill/resources/justlend_contracts.json
+++ b/justlend-skill/resources/justlend_contracts.json
@@ -1,0 +1,53 @@
+{
+  "comptroller": {
+    "mainnet": "TGjYzgCyPobsNS9n6WcbdLVR9dH7mWqFx7"
+  },
+  "markets": {
+    "mainnet": [
+      { "symbol": "TRX",  "jToken": "TE2RzoSV3wFK99w6J9UnnZ4vLfXYoxvRwP", "underlying": null,                                      "decimals": 6,  "jDecimals": 8, "is_native": true },
+      { "symbol": "USDT", "jToken": "TXJgMdjVX5dKiQaUi9QobwNxtSQaFqccvd", "underlying": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", "decimals": 6,  "jDecimals": 8, "is_native": false },
+      { "symbol": "USDC", "jToken": "TNSBA6KvSvMoTqQcEgpVK7VhHT3z7wifxy", "underlying": "TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8", "decimals": 6,  "jDecimals": 8, "is_native": false },
+      { "symbol": "USDD", "jToken": "TKFRELGGoRgiayhwJTNNLqCNjFoLBh3Mnf", "underlying": "TPYmHEhy5n8TCEfYGqW2rPxsghSfzghPDn", "decimals": 18, "jDecimals": 8, "is_native": false },
+      { "symbol": "SUN",  "jToken": "TGBr8uh9jBVHJhhkwSJvQN2ZAKzVkxDmno", "underlying": "TSSMHYeV2uE9qYH95DqyoCuNCzEL1NvU3S", "decimals": 18, "jDecimals": 8, "is_native": false },
+      { "symbol": "BTT",  "jToken": "TUaUHU9Dy8x5yNi1pKnFYqHWojot61Jfto", "underlying": "TAFjULxiVgT4qWk6UZwjqwZXTSaGaqnVp4", "decimals": 18, "jDecimals": 8, "is_native": false },
+      { "symbol": "JST",  "jToken": "TWQhCXaWz4eHK4Kd1ErSDHjMFPoPc9czts", "underlying": "TCFLL5dx5ZJdKnWuesXxi1VPwjLVmWZZy9", "decimals": 18, "jDecimals": 8, "is_native": false },
+      { "symbol": "WIN",  "jToken": "TRg6MnpsFXc82ymUPgf5qbj59ibxiEDWvv", "underlying": "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7", "decimals": 6,  "jDecimals": 8, "is_native": false },
+      { "symbol": "BTC",  "jToken": "TLeEu311Cbw63BcmMHDgDLu7fnk9fqGcqT", "underlying": "TN3W4H6rK2ce4vX9YnFQHwKENnHjoxb3m9", "decimals": 8,  "jDecimals": 8, "is_native": false }
+    ]
+  },
+  "abi": {
+    "jToken": {
+      "mint": { "type": "function", "name": "mint", "inputs": [{ "name": "mintAmount", "type": "uint256" }], "outputs": [{ "name": "", "type": "uint256" }], "stateMutability": "nonpayable" },
+      "mintNative": { "type": "function", "name": "mint", "inputs": [], "outputs": [], "stateMutability": "payable" },
+      "redeem": { "type": "function", "name": "redeem", "inputs": [{ "name": "redeemTokens", "type": "uint256" }], "outputs": [{ "name": "", "type": "uint256" }], "stateMutability": "nonpayable" },
+      "redeemUnderlying": { "type": "function", "name": "redeemUnderlying", "inputs": [{ "name": "redeemAmount", "type": "uint256" }], "outputs": [{ "name": "", "type": "uint256" }], "stateMutability": "nonpayable" },
+      "borrow": { "type": "function", "name": "borrow", "inputs": [{ "name": "borrowAmount", "type": "uint256" }], "outputs": [{ "name": "", "type": "uint256" }], "stateMutability": "nonpayable" },
+      "repayBorrow": { "type": "function", "name": "repayBorrow", "inputs": [{ "name": "repayAmount", "type": "uint256" }], "outputs": [{ "name": "", "type": "uint256" }], "stateMutability": "nonpayable" },
+      "repayBorrowNative": { "type": "function", "name": "repayBorrow", "inputs": [], "outputs": [], "stateMutability": "payable" },
+      "balanceOf": { "type": "function", "name": "balanceOf", "inputs": [{ "name": "owner", "type": "address" }], "outputs": [{ "name": "", "type": "uint256" }], "stateMutability": "view" },
+      "balanceOfUnderlying": { "type": "function", "name": "balanceOfUnderlying", "inputs": [{ "name": "owner", "type": "address" }], "outputs": [{ "name": "", "type": "uint256" }], "stateMutability": "nonpayable" },
+      "borrowBalanceCurrent": { "type": "function", "name": "borrowBalanceCurrent", "inputs": [{ "name": "account", "type": "address" }], "outputs": [{ "name": "", "type": "uint256" }], "stateMutability": "nonpayable" },
+      "exchangeRateCurrent": { "type": "function", "name": "exchangeRateCurrent", "inputs": [], "outputs": [{ "name": "", "type": "uint256" }], "stateMutability": "nonpayable" },
+      "exchangeRateStored": { "type": "function", "name": "exchangeRateStored", "inputs": [], "outputs": [{ "name": "", "type": "uint256" }], "stateMutability": "view" },
+      "borrowBalanceStored": { "type": "function", "name": "borrowBalanceStored", "inputs": [{ "name": "account", "type": "address" }], "outputs": [{ "name": "", "type": "uint256" }], "stateMutability": "view" },
+      "supplyRatePerBlock": { "type": "function", "name": "supplyRatePerBlock", "inputs": [], "outputs": [{ "name": "", "type": "uint256" }], "stateMutability": "view" },
+      "borrowRatePerBlock": { "type": "function", "name": "borrowRatePerBlock", "inputs": [], "outputs": [{ "name": "", "type": "uint256" }], "stateMutability": "view" }
+    },
+    "comptroller": {
+      "enterMarkets": { "type": "function", "name": "enterMarkets", "inputs": [{ "name": "jTokens", "type": "address[]" }], "outputs": [{ "name": "", "type": "uint256[]" }], "stateMutability": "nonpayable" },
+      "getAccountLiquidity": { "type": "function", "name": "getAccountLiquidity", "inputs": [{ "name": "account", "type": "address" }], "outputs": [{ "name": "", "type": "uint256" }, { "name": "", "type": "uint256" }, { "name": "", "type": "uint256" }], "stateMutability": "view" },
+      "getAllMarkets": { "type": "function", "name": "getAllMarkets", "inputs": [], "outputs": [{ "name": "", "type": "address[]" }], "stateMutability": "view" }
+    },
+    "trc20": {
+      "approve": { "type": "function", "name": "approve", "inputs": [{ "name": "spender", "type": "address" }, { "name": "amount", "type": "uint256" }], "outputs": [{ "name": "", "type": "bool" }], "stateMutability": "nonpayable" },
+      "allowance": { "type": "function", "name": "allowance", "inputs": [{ "name": "owner", "type": "address" }, { "name": "spender", "type": "address" }], "outputs": [{ "name": "", "type": "uint256" }], "stateMutability": "view" }
+    }
+  },
+  "notes": {
+    "jTokens": "jTokens represent your supplied position. They accrue interest over time as the exchange rate increases.",
+    "exchange_rate": "exchangeRateCurrent returns a scaled value (18 + underlying decimals - jToken decimals). Divide jToken balance * exchangeRate / 1e18 to get underlying.",
+    "enter_markets": "You must call enterMarkets on the Comptroller before borrowing against a supplied asset.",
+    "native_trx": "For jTRX, use mint() with callValue (payable) instead of mint(uint256). For repay, use repayBorrow() with callValue.",
+    "blocks_per_year": "TRON produces ~1 block per 3 seconds = ~10,512,000 blocks/year. APY = (1 + ratePerBlock)^blocksPerYear - 1"
+  }
+}

--- a/justlend-skill/resources/justlend_contracts.json
+++ b/justlend-skill/resources/justlend_contracts.json
@@ -1,6 +1,14 @@
 {
+  "health_factor": {
+    "min_threshold": 1.2,
+    "warn_threshold": 1.5,
+    "description": "Health factor = total collateral value (adjusted by collateral factors) / total borrow value. Borrowing is blocked if the estimated post-borrow health factor would fall below min_threshold. A warning is emitted if it falls below warn_threshold."
+  },
   "comptroller": {
     "mainnet": "TGjYzgCyPobsNS9n6WcbdLVR9dH7mWqFx7"
+  },
+  "price_oracle": {
+    "mainnet": "TYjSgFaoVCQFGRZPjhHUb3Mcs7SRqj9aYM"
   },
   "markets": {
     "mainnet": [
@@ -36,7 +44,12 @@
     "comptroller": {
       "enterMarkets": { "type": "function", "name": "enterMarkets", "inputs": [{ "name": "jTokens", "type": "address[]" }], "outputs": [{ "name": "", "type": "uint256[]" }], "stateMutability": "nonpayable" },
       "getAccountLiquidity": { "type": "function", "name": "getAccountLiquidity", "inputs": [{ "name": "account", "type": "address" }], "outputs": [{ "name": "", "type": "uint256" }, { "name": "", "type": "uint256" }, { "name": "", "type": "uint256" }], "stateMutability": "view" },
-      "getAllMarkets": { "type": "function", "name": "getAllMarkets", "inputs": [], "outputs": [{ "name": "", "type": "address[]" }], "stateMutability": "view" }
+      "getAllMarkets": { "type": "function", "name": "getAllMarkets", "inputs": [], "outputs": [{ "name": "", "type": "address[]" }], "stateMutability": "view" },
+      "oracle": { "type": "function", "name": "oracle", "inputs": [], "outputs": [{ "name": "", "type": "address" }], "stateMutability": "view" },
+      "markets": { "type": "function", "name": "markets", "inputs": [{ "name": "jToken", "type": "address" }], "outputs": [{ "name": "isListed", "type": "bool" }, { "name": "collateralFactorMantissa", "type": "uint256" }], "stateMutability": "view" }
+    },
+    "priceOracle": {
+      "getUnderlyingPrice": { "type": "function", "name": "getUnderlyingPrice", "inputs": [{ "name": "jToken", "type": "address" }], "outputs": [{ "name": "", "type": "uint256" }], "stateMutability": "view" }
     },
     "trc20": {
       "approve": { "type": "function", "name": "approve", "inputs": [{ "name": "spender", "type": "address" }, { "name": "amount", "type": "uint256" }], "outputs": [{ "name": "", "type": "bool" }], "stateMutability": "nonpayable" },

--- a/justlend-skill/scripts/borrow.js
+++ b/justlend-skill/scripts/borrow.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+/**
+ * borrow.js — Borrow assets against JustLend collateral.
+ *
+ * Usage:
+ *   node borrow.js <asset> <amount> [--dry-run]
+ */
+
+const { CONTRACTS, getTronWeb, resolveMarket, getComptroller, toSun, outputJSON, log } = require("./utils");
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) { console.error("Usage: node borrow.js <asset> <amount> [--collateral <SYMBOL>] [--dry-run]"); process.exit(1); }
+
+  const tronWeb = getTronWeb();
+  const market = resolveMarket(args[0]);
+  const amountHuman = args[1];
+  const dryRun = args.includes("--dry-run");
+  const amountRaw = String(toSun(amountHuman, market.decimals));
+
+  // Optional: enter a collateral market before borrowing
+  const collateralIdx = args.indexOf("--collateral");
+  const collateralSymbol = collateralIdx !== -1 ? args[collateralIdx + 1] : null;
+
+  const result = { action: "borrow", asset: market.symbol, amount: amountHuman, amount_raw: amountRaw, dry_run: dryRun };
+  log(`Borrowing ${amountHuman} ${market.symbol} from JustLend ...`);
+
+  if (dryRun) { result.status = "dry_run"; outputJSON(result); return; }
+
+  try {
+    // Enter collateral market if specified (enables that asset as collateral)
+    if (collateralSymbol) {
+      const collateralMarket = resolveMarket(collateralSymbol);
+      const comptrollerAddr = getComptroller();
+      const comptroller = await tronWeb.contract([CONTRACTS.abi.comptroller.enterMarkets], comptrollerAddr);
+      log(`Entering ${collateralSymbol} market as collateral ...`);
+      await comptroller.enterMarkets([collateralMarket.jToken]).send({ feeLimit: 100_000_000, shouldPollResponse: false });
+      result.collateral_market = collateralSymbol;
+      await new Promise((r) => setTimeout(r, 3000));
+    }
+
+    const jContract = await tronWeb.contract([CONTRACTS.abi.jToken.borrow], market.jToken);
+    const tx = await jContract.borrow(amountRaw).send({ feeLimit: 150_000_000, shouldPollResponse: false });
+    result.status = "submitted";
+    result.tx_id = tx;
+    log(`Transaction: ${tx}`);
+  } catch (e) {
+    result.status = "failed";
+    result.error = e.message || String(e);
+  }
+
+  outputJSON(result);
+}
+
+main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });

--- a/justlend-skill/scripts/borrow.js
+++ b/justlend-skill/scripts/borrow.js
@@ -4,10 +4,28 @@
  * borrow.js — Borrow assets against JustLend collateral.
  *
  * Usage:
- *   node borrow.js <asset> <amount> [--dry-run]
+ *   node borrow.js <asset> <amount> [--collateral <SYMBOL>] [--dry-run]
+ *
+ * Before executing, this script estimates the post-borrow health factor
+ * using the on-chain oracle price and current account liquidity. If the
+ * estimated health factor falls below the configured min_threshold
+ * (default 1.2), the borrow is blocked. If it falls below warn_threshold
+ * (default 1.5), a warning is emitted.
  */
 
-const { CONTRACTS, getTronWeb, resolveMarket, getComptroller, toSun, outputJSON, log } = require("./utils");
+const {
+  CONTRACTS,
+  HEALTH_FACTOR,
+  getTronWeb,
+  resolveMarket,
+  getComptroller,
+  toSun,
+  fromSun,
+  outputJSON,
+  log,
+  estimateHealthFactorAfterBorrow,
+  checkHealthFactorThreshold,
+} = require("./utils");
 
 async function main() {
   const args = process.argv.slice(2);
@@ -25,6 +43,26 @@ async function main() {
 
   const result = { action: "borrow", asset: market.symbol, amount: amountHuman, amount_raw: amountRaw, dry_run: dryRun };
   log(`Borrowing ${amountHuman} ${market.symbol} from JustLend ...`);
+
+  // Estimate post-borrow health factor
+  log("Estimating post-borrow health factor ...");
+  try {
+    const estimate = await estimateHealthFactorAfterBorrow(tronWeb, tronWeb.defaultAddress.base58, market, amountRaw);
+    result.health_factor_estimate = estimate;
+
+    if (estimate.error) {
+      log(`WARNING: Could not estimate health factor: ${estimate.error}`);
+    } else {
+      log(`Estimated health factor after borrow: ${estimate.estimated_health_factor}`);
+      log(`Collateral (USD): ${estimate.collateral_usd} | New total borrow (USD): ${estimate.total_borrow_usd_after}`);
+
+      // Block or warn based on thresholds
+      checkHealthFactorThreshold(estimate.estimated_health_factor, `Borrowing ${amountHuman} ${market.symbol}`);
+    }
+  } catch (e) {
+    log(`WARNING: Health factor estimation failed: ${e.message}. Proceeding with caution.`);
+    result.health_factor_estimate = { error: e.message };
+  }
 
   if (dryRun) { result.status = "dry_run"; outputJSON(result); return; }
 

--- a/justlend-skill/scripts/markets.js
+++ b/justlend-skill/scripts/markets.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+/**
+ * markets.js — List available JustLend markets with APY rates.
+ *
+ * Usage:
+ *   node markets.js
+ */
+
+const { CONTRACTS, getTronWeb, getMarkets, fromSun, outputJSON, log } = require("./utils");
+
+const BLOCKS_PER_YEAR = 10_512_000;
+
+async function main() {
+  const tronWeb = getTronWeb();
+  const markets = getMarkets();
+
+  log("Fetching JustLend market rates ...");
+
+  const results = [];
+  for (const market of markets) {
+    try {
+      const jContract = await tronWeb.contract(
+        [CONTRACTS.abi.jToken.supplyRatePerBlock, CONTRACTS.abi.jToken.borrowRatePerBlock],
+        market.jToken
+      );
+
+      const [supplyRate, borrowRate] = await Promise.all([
+        jContract.supplyRatePerBlock().call(),
+        jContract.borrowRatePerBlock().call(),
+      ]);
+
+      const supplyAPY = ((1 + Number(supplyRate) / 1e18) ** BLOCKS_PER_YEAR - 1) * 100;
+      const borrowAPY = ((1 + Number(borrowRate) / 1e18) ** BLOCKS_PER_YEAR - 1) * 100;
+
+      results.push({
+        symbol: market.symbol,
+        jToken: market.jToken,
+        supply_apy: supplyAPY.toFixed(2) + "%",
+        borrow_apy: borrowAPY.toFixed(2) + "%",
+        decimals: market.decimals,
+      });
+    } catch (e) {
+      results.push({ symbol: market.symbol, error: e.message });
+    }
+  }
+
+  outputJSON({ markets: results });
+}
+
+main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });

--- a/justlend-skill/scripts/markets.js
+++ b/justlend-skill/scripts/markets.js
@@ -7,12 +7,12 @@
  *   node markets.js
  */
 
-const { CONTRACTS, getTronWeb, getMarkets, fromSun, outputJSON, log } = require("./utils");
+const { CONTRACTS, getTronWebReadOnly, getMarkets, fromSun, outputJSON, log } = require("./utils");
 
 const BLOCKS_PER_YEAR = 10_512_000;
 
 async function main() {
-  const tronWeb = getTronWeb();
+  const tronWeb = getTronWebReadOnly();
   const markets = getMarkets();
 
   log("Fetching JustLend market rates ...");

--- a/justlend-skill/scripts/position.js
+++ b/justlend-skill/scripts/position.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+/**
+ * position.js — Check supplied and borrowed amounts across JustLend markets.
+ *
+ * Usage:
+ *   node position.js [walletAddress]
+ */
+
+const { CONTRACTS, getTronWeb, getMarkets, getComptroller, fromSun, outputJSON, log } = require("./utils");
+
+async function main() {
+  const tronWeb = getTronWeb();
+  const address = process.argv[2] || tronWeb.defaultAddress.base58;
+  const markets = getMarkets();
+  const comptrollerAddr = getComptroller();
+
+  log(`Checking JustLend positions for ${address} ...`);
+
+  // Account liquidity from comptroller
+  let liquidity = null;
+  try {
+    const comptroller = await tronWeb.contract(
+      [CONTRACTS.abi.comptroller.getAccountLiquidity],
+      comptrollerAddr
+    );
+    const liq = await comptroller.getAccountLiquidity(address).call();
+    liquidity = {
+      error_code: Number(liq[0]),
+      excess_liquidity_usd: fromSun(liq[1], 18),
+      shortfall_usd: fromSun(liq[2], 18),
+    };
+  } catch (e) {
+    liquidity = { error: e.message };
+  }
+
+  const positions = [];
+  for (const market of markets) {
+    try {
+      // Use view functions (exchangeRateStored, borrowBalanceStored) instead of
+      // non-view variants (exchangeRateCurrent, borrowBalanceCurrent) because
+      // TronWeb's .call() on non-view functions returns 0 instead of the actual value.
+      const jContract = await tronWeb.contract(
+        [
+          CONTRACTS.abi.jToken.balanceOf,
+          CONTRACTS.abi.jToken.exchangeRateStored,
+          CONTRACTS.abi.jToken.borrowBalanceStored,
+        ],
+        market.jToken
+      );
+
+      const [jBalance, exchangeRate, borrowed] = await Promise.all([
+        jContract.balanceOf(address).call(),
+        jContract.exchangeRateStored().call(),
+        jContract.borrowBalanceStored(address).call(),
+      ]);
+
+      if (Number(jBalance) === 0 && Number(borrowed) === 0) continue;
+
+      // supplied = jBalance * exchangeRate / 1e18
+      // exchangeRate is scaled to 18 + underlyingDecimals - jTokenDecimals
+      const suppliedRaw = (BigInt(jBalance) * BigInt(exchangeRate)) / BigInt(10 ** 18);
+
+      positions.push({
+        symbol: market.symbol,
+        jToken: market.jToken,
+        jToken_balance: fromSun(jBalance, market.jDecimals),
+        supplied: fromSun(suppliedRaw, market.decimals),
+        borrowed: fromSun(borrowed, market.decimals),
+      });
+    } catch (e) {
+      // Skip markets with errors
+    }
+  }
+
+  outputJSON({ wallet: address, liquidity, positions });
+}
+
+main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });

--- a/justlend-skill/scripts/position.js
+++ b/justlend-skill/scripts/position.js
@@ -7,11 +7,12 @@
  *   node position.js [walletAddress]
  */
 
-const { CONTRACTS, HEALTH_FACTOR, getTronWeb, getMarkets, getComptroller, fromSun, outputJSON, log, getHealthFactor } = require("./utils");
+const { CONTRACTS, HEALTH_FACTOR, getTronWeb, getTronWebReadOnly, getMarkets, getComptroller, fromSun, outputJSON, log, getHealthFactor } = require("./utils");
 
 async function main() {
-  const tronWeb = getTronWeb();
-  const address = process.argv[2] || tronWeb.defaultAddress.base58;
+  const addressArg = process.argv[2];
+  const tronWeb = addressArg ? getTronWebReadOnly() : getTronWeb();
+  const address = addressArg || tronWeb.defaultAddress.base58;
   const markets = getMarkets();
   const comptrollerAddr = getComptroller();
 

--- a/justlend-skill/scripts/position.js
+++ b/justlend-skill/scripts/position.js
@@ -7,7 +7,7 @@
  *   node position.js [walletAddress]
  */
 
-const { CONTRACTS, getTronWeb, getMarkets, getComptroller, fromSun, outputJSON, log } = require("./utils");
+const { CONTRACTS, HEALTH_FACTOR, getTronWeb, getMarkets, getComptroller, fromSun, outputJSON, log, getHealthFactor } = require("./utils");
 
 async function main() {
   const tronWeb = getTronWeb();
@@ -73,7 +73,23 @@ async function main() {
     }
   }
 
-  outputJSON({ wallet: address, liquidity, positions });
+  // Compute health factor
+  let healthFactor = null;
+  try {
+    healthFactor = await getHealthFactor(tronWeb, address);
+    if (healthFactor.health_factor !== null && healthFactor.health_factor !== Infinity) {
+      log(`Health factor: ${healthFactor.health_factor}`);
+      if (healthFactor.health_factor < HEALTH_FACTOR.min_threshold) {
+        log(`CRITICAL: Health factor ${healthFactor.health_factor} is below minimum threshold ${HEALTH_FACTOR.min_threshold}. Liquidation risk is imminent!`);
+      } else if (healthFactor.health_factor < HEALTH_FACTOR.warn_threshold) {
+        log(`WARNING: Health factor ${healthFactor.health_factor} is below recommended safe level ${HEALTH_FACTOR.warn_threshold}.`);
+      }
+    }
+  } catch (e) {
+    healthFactor = { error: e.message };
+  }
+
+  outputJSON({ wallet: address, liquidity, health_factor: healthFactor, positions });
 }
 
 main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });

--- a/justlend-skill/scripts/repay.js
+++ b/justlend-skill/scripts/repay.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+/**
+ * repay.js — Repay borrowed assets on JustLend.
+ *
+ * Usage:
+ *   node repay.js <asset> <amount|all> [--dry-run]
+ */
+
+const { CONTRACTS, getTronWeb, resolveMarket, toSun, fromSun, outputJSON, log } = require("./utils");
+
+const MAX_UINT256 = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) { console.error("Usage: node repay.js <asset> <amount|all> [--dry-run]"); process.exit(1); }
+
+  const tronWeb = getTronWeb();
+  const market = resolveMarket(args[0]);
+  const amountArg = args[1];
+  const dryRun = args.includes("--dry-run");
+  const walletAddress = tronWeb.defaultAddress.base58;
+
+  // Use max uint256 for "all" to repay full borrow
+  const amountRaw = amountArg.toLowerCase() === "all" ? MAX_UINT256 : String(toSun(amountArg, market.decimals));
+
+  const result = { action: "repay", asset: market.symbol, amount: amountArg, dry_run: dryRun };
+  log(`Repaying ${amountArg} ${market.symbol} on JustLend ...`);
+
+  if (dryRun) { result.status = "dry_run"; outputJSON(result); return; }
+
+  try {
+    if (market.is_native) {
+      // TRX: use payable repayBorrow
+      const jContract = await tronWeb.contract([CONTRACTS.abi.jToken.repayBorrowNative], market.jToken);
+      const tx = await jContract.repayBorrow().send({ callValue: Number(amountRaw === MAX_UINT256 ? 0 : amountRaw), feeLimit: 150_000_000, shouldPollResponse: false });
+      result.status = "submitted"; result.tx_id = tx;
+    } else {
+      // TRC20: approve then repayBorrow
+      const underlying = await tronWeb.contract([CONTRACTS.abi.trc20.approve, CONTRACTS.abi.trc20.allowance], market.underlying);
+      const allowance = await underlying.allowance(walletAddress, market.jToken).call();
+      if (BigInt(allowance) < BigInt(amountRaw === MAX_UINT256 ? "1" : amountRaw)) {
+        log("Approving jToken to spend underlying ...");
+        await underlying.approve(market.jToken, MAX_UINT256).send({ feeLimit: 50_000_000, shouldPollResponse: false });
+        await new Promise((r) => setTimeout(r, 4000));
+      }
+      const jContract = await tronWeb.contract([CONTRACTS.abi.jToken.repayBorrow], market.jToken);
+      const tx = await jContract.repayBorrow(amountRaw).send({ feeLimit: 150_000_000, shouldPollResponse: false });
+      result.status = "submitted"; result.tx_id = tx;
+    }
+    log(`Transaction: ${result.tx_id}`);
+  } catch (e) {
+    result.status = "failed";
+    result.error = e.message || String(e);
+  }
+
+  outputJSON(result);
+}
+
+main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });

--- a/justlend-skill/scripts/supply.js
+++ b/justlend-skill/scripts/supply.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+/**
+ * supply.js — Supply assets to JustLend to earn interest.
+ *
+ * Usage:
+ *   node supply.js <asset> <amount> [--dry-run]
+ *   node supply.js TRX 100 --dry-run
+ *   node supply.js USDT 50
+ */
+
+const { CONTRACTS, getTronWeb, getComptroller, resolveMarket, toSun, fromSun, outputJSON, log } = require("./utils");
+
+const MAX_UINT256 = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) { console.error("Usage: node supply.js <asset> <amount> [--dry-run] [--no-collateral]"); process.exit(1); }
+
+  const tronWeb = getTronWeb();
+  const market = resolveMarket(args[0]);
+  const amountHuman = args[1];
+  const dryRun = args.includes("--dry-run");
+  const noCollateral = args.includes("--no-collateral");
+  const amountRaw = String(toSun(amountHuman, market.decimals));
+
+  const result = { action: "supply", asset: market.symbol, amount: amountHuman, amount_raw: amountRaw, jToken: market.jToken, dry_run: dryRun };
+  log(`Supplying ${amountHuman} ${market.symbol} to JustLend ...`);
+
+  if (dryRun) { result.status = "dry_run"; outputJSON(result); return; }
+
+  try {
+    if (market.is_native) {
+      // TRX: use payable mint()
+      const jContract = await tronWeb.contract([CONTRACTS.abi.jToken.mintNative], market.jToken);
+      const tx = await jContract.mint().send({ callValue: Number(amountRaw), feeLimit: 150_000_000, shouldPollResponse: false });
+      result.status = "submitted";
+      result.tx_id = tx;
+    } else {
+      // TRC20: approve then mint(amount)
+      const underlying = await tronWeb.contract([CONTRACTS.abi.trc20.approve, CONTRACTS.abi.trc20.allowance], market.underlying);
+      const allowance = await underlying.allowance(tronWeb.defaultAddress.base58, market.jToken).call();
+      if (BigInt(allowance) < BigInt(amountRaw)) {
+        log("Approving jToken to spend underlying ...");
+        await underlying.approve(market.jToken, MAX_UINT256).send({ feeLimit: 50_000_000, shouldPollResponse: false });
+        await new Promise((r) => setTimeout(r, 4000));
+      }
+      const jContract = await tronWeb.contract([CONTRACTS.abi.jToken.mint], market.jToken);
+      const tx = await jContract.mint(amountRaw).send({ feeLimit: 150_000_000, shouldPollResponse: false });
+      result.status = "submitted";
+      result.tx_id = tx;
+    }
+    log(`Transaction: ${result.tx_id}`);
+
+    // Enable as collateral by default (needed for borrowing against this asset)
+    if (!noCollateral) {
+      log("Entering market to enable as collateral ...");
+      await new Promise((r) => setTimeout(r, 3000));
+      const comptrollerAddr = getComptroller();
+      const comptroller = await tronWeb.contract([CONTRACTS.abi.comptroller.enterMarkets], comptrollerAddr);
+      const enterTx = await comptroller.enterMarkets([market.jToken]).send({ feeLimit: 100_000_000, shouldPollResponse: false });
+      result.collateral_enabled = true;
+      result.enter_markets_tx = enterTx;
+      log(`Collateral enabled: ${enterTx}`);
+    }
+  } catch (e) {
+    result.status = "failed";
+    result.error = e.message || String(e);
+  }
+
+  outputJSON(result);
+}
+
+main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });

--- a/justlend-skill/scripts/utils.js
+++ b/justlend-skill/scripts/utils.js
@@ -1,0 +1,61 @@
+/**
+ * Shared utilities for JustLend skill scripts.
+ */
+
+const { TronWeb } = require("tronweb");
+const path = require("path");
+const fs = require("fs");
+
+const CONTRACTS = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "resources", "justlend_contracts.json"), "utf-8")
+);
+
+const TRX_DECIMALS = 6;
+
+function getTronWeb() {
+  const network = (process.env.TRON_NETWORK || "mainnet").toLowerCase();
+  const hosts = { mainnet: "https://api.trongrid.io", nile: "https://nile.trongrid.io", shasta: "https://api.shasta.trongrid.io" };
+  const fullHost = hosts[network];
+  if (!fullHost) throw new Error(`Unknown network "${network}".`);
+  const privateKey = process.env.TRON_PRIVATE_KEY;
+  if (!privateKey) throw new Error("TRON_PRIVATE_KEY environment variable is required");
+  const opts = { fullHost, privateKey };
+  if (process.env.TRONGRID_API_KEY) opts.headers = { "TRON-PRO-API-KEY": process.env.TRONGRID_API_KEY };
+  return new TronWeb(opts);
+}
+
+function getMarkets() {
+  const network = (process.env.TRON_NETWORK || "mainnet").toLowerCase();
+  return CONTRACTS.markets[network] || [];
+}
+
+function getComptroller() {
+  const network = (process.env.TRON_NETWORK || "mainnet").toLowerCase();
+  return CONTRACTS.comptroller[network];
+}
+
+function resolveMarket(assetSymbol) {
+  const markets = getMarkets();
+  const match = markets.find((m) => m.symbol.toLowerCase() === assetSymbol.toLowerCase());
+  if (!match) throw new Error(`Unknown asset "${assetSymbol}". Available: ${markets.map((m) => m.symbol).join(", ")}`);
+  return match;
+}
+
+function toSun(amount, decimals) {
+  const parts = String(amount).split(".");
+  const whole = parts[0] || "0";
+  const frac = (parts[1] || "").slice(0, decimals).padEnd(decimals, "0");
+  return BigInt(whole) * BigInt(10 ** decimals) + BigInt(frac);
+}
+
+function fromSun(raw, decimals) {
+  const str = String(raw).padStart(decimals + 1, "0");
+  const whole = str.slice(0, str.length - decimals) || "0";
+  const frac = str.slice(str.length - decimals).replace(/0+$/, "");
+  return frac ? `${whole}.${frac}` : whole;
+}
+
+function outputJSON(data) { process.stdout.write(JSON.stringify(data, null, 2) + "\n"); }
+function log(msg) { process.stderr.write(msg + "\n"); }
+
+module.exports = { CONTRACTS, getTronWeb, getMarkets, getComptroller, resolveMarket, toSun, fromSun, outputJSON, log };

--- a/justlend-skill/scripts/utils.js
+++ b/justlend-skill/scripts/utils.js
@@ -11,6 +11,7 @@ const CONTRACTS = JSON.parse(
 );
 
 const TRX_DECIMALS = 6;
+const HEALTH_FACTOR = CONTRACTS.health_factor;
 
 function getTronWeb() {
   const network = (process.env.TRON_NETWORK || "mainnet").toLowerCase();
@@ -32,6 +33,11 @@ function getMarkets() {
 function getComptroller() {
   const network = (process.env.TRON_NETWORK || "mainnet").toLowerCase();
   return CONTRACTS.comptroller[network];
+}
+
+function getPriceOracle() {
+  const network = (process.env.TRON_NETWORK || "mainnet").toLowerCase();
+  return CONTRACTS.price_oracle[network];
 }
 
 function resolveMarket(assetSymbol) {
@@ -58,4 +64,165 @@ function fromSun(raw, decimals) {
 function outputJSON(data) { process.stdout.write(JSON.stringify(data, null, 2) + "\n"); }
 function log(msg) { process.stderr.write(msg + "\n"); }
 
-module.exports = { CONTRACTS, getTronWeb, getMarkets, getComptroller, resolveMarket, toSun, fromSun, outputJSON, log };
+/**
+ * Compute health factor from comptroller's getAccountLiquidity output.
+ *
+ * getAccountLiquidity returns (error, excessLiquidity, shortfall) in USD (18 decimals).
+ * - If excessLiquidity > 0: account is solvent. We reconstruct HF from the liquidity values.
+ * - If shortfall > 0: account is underwater (HF < 1).
+ * - If both are 0 with no borrows: HF is Infinity (no risk).
+ *
+ * The comptroller defines: excessLiquidity = sumCollateral - sumBorrowPlusEffects
+ * So: HF = sumCollateral / sumBorrows = (excessLiquidity + sumBorrows) / sumBorrows
+ *
+ * We also need sumBorrows to compute this. We get it by iterating positions.
+ */
+async function getHealthFactor(tronWeb, address) {
+  const comptrollerAddr = getComptroller();
+  const comptroller = await tronWeb.contract(
+    [CONTRACTS.abi.comptroller.getAccountLiquidity],
+    comptrollerAddr
+  );
+  const liq = await comptroller.getAccountLiquidity(address).call();
+  const errCode = Number(liq[0]);
+  const excessLiquidity = BigInt(liq[1]);
+  const shortfall = BigInt(liq[2]);
+
+  if (errCode !== 0) return { error: `Comptroller error code: ${errCode}`, health_factor: null };
+
+  // Get total borrows in USD by summing across markets
+  const markets = getMarkets();
+  const oracleAddr = getPriceOracle();
+  const oracle = await tronWeb.contract(
+    [CONTRACTS.abi.priceOracle.getUnderlyingPrice],
+    oracleAddr
+  );
+
+  let totalBorrowUSD = 0n;
+  for (const market of markets) {
+    try {
+      const jContract = await tronWeb.contract(
+        [CONTRACTS.abi.jToken.borrowBalanceStored],
+        market.jToken
+      );
+      const borrowed = BigInt(await jContract.borrowBalanceStored(address).call());
+      if (borrowed === 0n) continue;
+
+      const price = BigInt(await oracle.getUnderlyingPrice(market.jToken).call());
+      // price is scaled to 18 decimals in USD. borrowed is in underlying decimals.
+      // borrowUSD = borrowed * price / 10^underlyingDecimals
+      totalBorrowUSD += (borrowed * price) / BigInt(10 ** market.decimals);
+    } catch (e) {
+      // Skip markets with errors
+    }
+  }
+
+  if (totalBorrowUSD === 0n) {
+    return { health_factor: Infinity, excess_liquidity_usd: fromSun(excessLiquidity, 18), shortfall_usd: "0", total_borrow_usd: "0" };
+  }
+
+  // HF = (excessLiquidity + totalBorrowUSD) / totalBorrowUSD  (when no shortfall)
+  // HF = (totalBorrowUSD - shortfall) / totalBorrowUSD         (when shortfall > 0)
+  let hf;
+  if (shortfall > 0n) {
+    const collateralUSD = totalBorrowUSD - shortfall;
+    hf = Number(collateralUSD * 10000n / totalBorrowUSD) / 10000;
+  } else {
+    const collateralUSD = excessLiquidity + totalBorrowUSD;
+    hf = Number(collateralUSD * 10000n / totalBorrowUSD) / 10000;
+  }
+
+  return {
+    health_factor: Math.round(hf * 100) / 100,
+    excess_liquidity_usd: fromSun(excessLiquidity, 18),
+    shortfall_usd: fromSun(shortfall, 18),
+    total_borrow_usd: fromSun(totalBorrowUSD, 18),
+  };
+}
+
+/**
+ * Estimate health factor after a new borrow.
+ * Uses current account liquidity and subtracts the new borrow's USD value.
+ */
+async function estimateHealthFactorAfterBorrow(tronWeb, address, borrowMarket, borrowAmountRaw) {
+  const comptrollerAddr = getComptroller();
+  const comptroller = await tronWeb.contract(
+    [CONTRACTS.abi.comptroller.getAccountLiquidity],
+    comptrollerAddr
+  );
+  const liq = await comptroller.getAccountLiquidity(address).call();
+  const errCode = Number(liq[0]);
+  const excessLiquidity = BigInt(liq[1]);
+  const shortfall = BigInt(liq[2]);
+
+  if (errCode !== 0) return { error: `Comptroller error code: ${errCode}`, estimated_health_factor: null };
+
+  // Get oracle price for the borrow asset
+  const oracleAddr = getPriceOracle();
+  const oracle = await tronWeb.contract(
+    [CONTRACTS.abi.priceOracle.getUnderlyingPrice],
+    oracleAddr
+  );
+  const price = BigInt(await oracle.getUnderlyingPrice(borrowMarket.jToken).call());
+  const newBorrowUSD = (BigInt(borrowAmountRaw) * price) / BigInt(10 ** borrowMarket.decimals);
+
+  // Get current total borrows in USD
+  const markets = getMarkets();
+  let totalBorrowUSD = 0n;
+  for (const market of markets) {
+    try {
+      const jContract = await tronWeb.contract(
+        [CONTRACTS.abi.jToken.borrowBalanceStored],
+        market.jToken
+      );
+      const borrowed = BigInt(await jContract.borrowBalanceStored(address).call());
+      if (borrowed === 0n) continue;
+      const mPrice = BigInt(await oracle.getUnderlyingPrice(market.jToken).call());
+      totalBorrowUSD += (borrowed * mPrice) / BigInt(10 ** market.decimals);
+    } catch (e) { /* skip */ }
+  }
+
+  const newTotalBorrowUSD = totalBorrowUSD + newBorrowUSD;
+  if (newTotalBorrowUSD === 0n) {
+    return { estimated_health_factor: Infinity, new_borrow_usd: fromSun(newBorrowUSD, 18) };
+  }
+
+  // Current collateral = excessLiquidity + totalBorrowUSD (or totalBorrowUSD - shortfall)
+  let collateralUSD;
+  if (shortfall > 0n) {
+    collateralUSD = totalBorrowUSD - shortfall;
+  } else {
+    collateralUSD = excessLiquidity + totalBorrowUSD;
+  }
+
+  const hf = Number(collateralUSD * 10000n / newTotalBorrowUSD) / 10000;
+
+  return {
+    estimated_health_factor: Math.round(hf * 100) / 100,
+    current_borrow_usd: fromSun(totalBorrowUSD, 18),
+    new_borrow_usd: fromSun(newBorrowUSD, 18),
+    total_borrow_usd_after: fromSun(newTotalBorrowUSD, 18),
+    collateral_usd: fromSun(collateralUSD, 18),
+  };
+}
+
+/**
+ * Check health factor against configured thresholds.
+ * Blocks execution if below min_threshold, warns if below warn_threshold.
+ */
+function checkHealthFactorThreshold(hf, context) {
+  if (hf === Infinity) return; // no borrows, safe
+  if (hf < HEALTH_FACTOR.min_threshold) {
+    outputJSON({
+      error: `Health factor safeguard: ${context} would result in a health factor of ${hf}, which is below the minimum threshold of ${HEALTH_FACTOR.min_threshold}. Reduce the borrow amount or supply more collateral.`,
+      estimated_health_factor: hf,
+      min_threshold: HEALTH_FACTOR.min_threshold,
+    });
+    process.exit(1);
+  }
+  if (hf < HEALTH_FACTOR.warn_threshold) {
+    log(`WARNING: ${context} will result in a health factor of ${hf}, which is below the recommended safe level of ${HEALTH_FACTOR.warn_threshold}. Liquidation risk is elevated.`);
+  }
+}
+
+module.exports = { CONTRACTS, HEALTH_FACTOR, getTronWeb, getMarkets, getComptroller, getPriceOracle, resolveMarket, toSun, fromSun, outputJSON, log, getHealthFactor, estimateHealthFactorAfterBorrow, checkHealthFactorThreshold };

--- a/justlend-skill/scripts/utils.js
+++ b/justlend-skill/scripts/utils.js
@@ -25,6 +25,21 @@ function getTronWeb() {
   return new TronWeb(opts);
 }
 
+function getTronWebReadOnly() {
+  const network = (process.env.TRON_NETWORK || "mainnet").toLowerCase();
+  const hosts = { mainnet: "https://api.trongrid.io", nile: "https://nile.trongrid.io", shasta: "https://api.shasta.trongrid.io" };
+  const fullHost = hosts[network];
+  if (!fullHost) throw new Error(`Unknown network "${network}".`);
+  const opts = { fullHost };
+  if (process.env.TRONGRID_API_KEY) opts.headers = { "TRON-PRO-API-KEY": process.env.TRONGRID_API_KEY };
+  const tw = new TronWeb(opts);
+  tw.defaultAddress = {
+    hex: "410000000000000000000000000000000000000000",
+    base58: "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb",
+  };
+  return tw;
+}
+
 function getMarkets() {
   const network = (process.env.TRON_NETWORK || "mainnet").toLowerCase();
   return CONTRACTS.markets[network] || [];
@@ -225,4 +240,4 @@ function checkHealthFactorThreshold(hf, context) {
   }
 }
 
-module.exports = { CONTRACTS, HEALTH_FACTOR, getTronWeb, getMarkets, getComptroller, getPriceOracle, resolveMarket, toSun, fromSun, outputJSON, log, getHealthFactor, estimateHealthFactorAfterBorrow, checkHealthFactorThreshold };
+module.exports = { CONTRACTS, HEALTH_FACTOR, getTronWeb, getTronWebReadOnly, getMarkets, getComptroller, getPriceOracle, resolveMarket, toSun, fromSun, outputJSON, log, getHealthFactor, estimateHealthFactorAfterBorrow, checkHealthFactorThreshold };

--- a/justlend-skill/scripts/withdraw.js
+++ b/justlend-skill/scripts/withdraw.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+/**
+ * withdraw.js — Withdraw supplied assets from JustLend.
+ *
+ * Usage:
+ *   node withdraw.js <asset> <amount|all> [--dry-run]
+ */
+
+const { CONTRACTS, getTronWeb, resolveMarket, toSun, fromSun, outputJSON, log } = require("./utils");
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) { console.error("Usage: node withdraw.js <asset> <amount|all> [--dry-run]"); process.exit(1); }
+
+  const tronWeb = getTronWeb();
+  const market = resolveMarket(args[0]);
+  const amountArg = args[1];
+  const dryRun = args.includes("--dry-run");
+  const walletAddress = tronWeb.defaultAddress.base58;
+
+  const jContract = await tronWeb.contract(
+    [CONTRACTS.abi.jToken.balanceOf, CONTRACTS.abi.jToken.redeem, CONTRACTS.abi.jToken.redeemUnderlying],
+    market.jToken
+  );
+
+  const result = { action: "withdraw", asset: market.symbol, jToken: market.jToken, dry_run: dryRun };
+
+  if (amountArg.toLowerCase() === "all") {
+    const jBalance = await jContract.balanceOf(walletAddress).call();
+    if (Number(jBalance) === 0) { outputJSON({ error: "No jTokens to redeem." }); process.exit(1); }
+    result.jToken_balance = fromSun(jBalance, market.jDecimals);
+    result.redeem_method = "redeem (all jTokens)";
+    log(`Withdrawing all jTokens (${result.jToken_balance}) ...`);
+    if (dryRun) { result.status = "dry_run"; outputJSON(result); return; }
+    try {
+      const tx = await jContract.redeem(String(jBalance)).send({ feeLimit: 150_000_000, shouldPollResponse: false });
+      result.status = "submitted"; result.tx_id = tx;
+    } catch (e) { result.status = "failed"; result.error = e.message || String(e); }
+  } else {
+    const amountRaw = String(toSun(amountArg, market.decimals));
+    result.amount = amountArg;
+    result.amount_raw = amountRaw;
+    result.redeem_method = "redeemUnderlying (exact amount)";
+    log(`Withdrawing ${amountArg} ${market.symbol} ...`);
+    if (dryRun) { result.status = "dry_run"; outputJSON(result); return; }
+    try {
+      const tx = await jContract.redeemUnderlying(amountRaw).send({ feeLimit: 150_000_000, shouldPollResponse: false });
+      result.status = "submitted"; result.tx_id = tx;
+    } catch (e) { result.status = "failed"; result.error = e.message || String(e); }
+  }
+
+  outputJSON(result);
+}
+
+main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });


### PR DESCRIPTION
## Summary
- Adds `justlend-skill` for supplying and borrowing assets on JustLend DAO (TRON's largest lending protocol)
- Browse lending markets with APY rates
- View lending positions and health factor
- Supply and withdraw assets
- Borrow and repay loans

## Scripts
- `markets.js` — Browse available lending markets
- `position.js` — View lending positions and health
- `supply.js` — Supply assets to earn interest
- `withdraw.js` — Withdraw supplied assets
- `borrow.js` — Borrow against collateral
- `repay.js` — Repay borrowed assets

Source: https://github.com/M2M-TRC8004-Registry/justlend-skill