### PR TITLE
Add SunPump Trading skill

### DIFF
--- a/sunpump-skill/README.md
+++ b/sunpump-skill/README.md
@@ -1,0 +1,58 @@
+# SunPump Trading Skill
+
+> Buy and sell meme tokens on SunPump, the TRON bonding-curve launchpad.
+
+## Overview
+
+This skill provides AI agents with scripts to trade tokens on [SunPump](https://sunpump.meme) — the leading fair-launch meme token platform on TRON. Tokens are priced via a bonding curve and automatically migrate to SunSwap V2 once they reach ~$69,420 market cap.
+
+## Files
+
+```
+sunpump/
+├── SKILL.md                          # Full agent instructions
+├── README.md                         # This file
+├── package.json                      # Node.js dependencies
+├── scripts/
+│   ├── utils.js                      # Shared utilities
+│   ├── balance.js                    # Check TRX & token balances
+│   ├── price.js                      # Query price, state, estimates
+│   ├── buy.js                        # Purchase tokens with TRX
+│   └── sell.js                       # Sell tokens for TRX
+├── resources/
+│   └── sunpump_contracts.json        # Contract addresses & ABIs
+└── examples/
+```
+
+## Network
+
+| Network | Launcher Contract | API Endpoint |
+|---|---|---|
+| Mainnet | `TTfvyrAz86hbZk5iDpKD78pqLGgi8C7AAw` | `https://api.trongrid.io` |
+| Nile | `TTfvyrAz86hbZk5iDpKD78pqLGgi8C7AAw` | `https://nile.trongrid.io` |
+
+## Quick Start
+
+```bash
+cd sunpump && npm install
+
+export TRON_PRIVATE_KEY="<your-key>"
+export TRON_NETWORK="mainnet"
+
+# Check balance
+node scripts/balance.js
+
+# Get price
+node scripts/price.js <tokenAddress>
+
+# Buy (dry run)
+node scripts/buy.js <tokenAddress> 100 --dry-run
+
+# Sell
+node scripts/sell.js <tokenAddress> all
+```
+
+## Dependencies
+
+- Node.js 18+
+- [tronweb](https://www.npmjs.com/package/tronweb)

--- a/sunpump-skill/README.md
+++ b/sunpump-skill/README.md
@@ -9,7 +9,7 @@ This skill provides AI agents with scripts to trade tokens on [SunPump](https://
 ## Files
 
 ```
-sunpump/
+sunpump-skill/
 ├── SKILL.md                          # Full agent instructions
 ├── README.md                         # This file
 ├── package.json                      # Node.js dependencies
@@ -34,7 +34,7 @@ sunpump/
 ## Quick Start
 
 ```bash
-cd sunpump && npm install
+cd sunpump-skill && npm install
 
 export TRON_PRIVATE_KEY="<your-key>"
 export TRON_NETWORK="mainnet"

--- a/sunpump-skill/SKILL.md
+++ b/sunpump-skill/SKILL.md
@@ -98,7 +98,7 @@ node scripts/price.js TTokenAddress123 --sell 50000
 |---|---|---|
 | `tokenAddress` | **Yes** | SunPump token address |
 | `trxAmount` | **Yes** | TRX to spend (human-readable, e.g. `100`) |
-| `--slippage <pct>` | No | Slippage tolerance, default `5` (percent) |
+| `--slippage <pct>` | No | Slippage tolerance (default: `5`%, range: `0.1`–`50`%) |
 | `--dry-run` | No | Estimate only, do not send transaction |
 
 ```bash
@@ -122,7 +122,7 @@ node scripts/buy.js TTokenAddress123 50 --slippage 10
 |---|---|---|
 | `tokenAddress` | **Yes** | SunPump token address |
 | `tokenAmount` | **Yes** | Tokens to sell (human-readable) or `all` |
-| `--slippage <pct>` | No | Slippage tolerance, default `5` (percent) |
+| `--slippage <pct>` | No | Slippage tolerance (default: `5`%, range: `0.1`–`50`%) |
 | `--dry-run` | No | Estimate only, do not send transaction |
 
 ```bash
@@ -198,6 +198,51 @@ When a user asks to trade on SunPump, follow this sequence:
 4. **Get explicit confirmation** before executing any transaction.
 5. **Execute** the trade and report the transaction ID.
 6. **Verify** the result by checking the balance after the trade.
+
+---
+
+## Slippage Tolerance Configuration
+
+Slippage parameters are defined in `resources/sunpump_contracts.json` under the `slippage` key:
+
+| Parameter | Value | Description |
+|---|---|---|
+| `default_percent` | `5` | Applied when `--slippage` is omitted |
+| `min_percent` | `0.1` | Minimum allowed slippage — rejects values below this |
+| `max_percent` | `50` | Maximum allowed slippage — rejects values above this |
+| `warn_above_percent` | `10` | Slippage above this triggers a warning to stderr |
+
+The `validateSlippage()` function in `utils.js` enforces these bounds. If a user-supplied slippage is outside `[min, max]`, the script exits with a structured error. If it exceeds `warn_above_percent`, a warning is logged but execution continues.
+
+```bash
+# Uses default 5% slippage
+node scripts/buy.js TTokenAddress123 100
+
+# Explicit 2% slippage
+node scripts/buy.js TTokenAddress123 100 --slippage 2
+
+# 15% slippage — logs a warning, but proceeds
+node scripts/buy.js TTokenAddress123 100 --slippage 15
+
+# 60% slippage — rejected (exceeds max_percent)
+node scripts/buy.js TTokenAddress123 100 --slippage 60
+```
+
+---
+
+## SunSwap V2 Migration Handling
+
+When a token reaches the ~$69,420 market cap threshold, SunPump automatically migrates its liquidity to **SunSwap V2**. The bonding curve closes and all buy/sell scripts will stop working for that token.
+
+All trading scripts (`buy.js`, `sell.js`) check `getTokenState()` before executing. If the token has migrated (state ≠ 0), the script exits with a structured error containing:
+
+- **`migration.reason`** — why the bonding curve is closed
+- **`migration.sunswap_router`** — the SunSwap V2 router address for the current network (if available)
+- **`migration.action`** — directs the agent to use the SunSwap skill instead
+
+`price.js` also reports migration status in its output when querying a migrated token, but does not exit with an error since it is a read-only query.
+
+**Agent behavior:** When a migration error is received, the agent should inform the user that the token has graduated from SunPump and offer to trade it via the SunSwap skill instead. Do not retry with SunPump scripts.
 
 ---
 

--- a/sunpump-skill/SKILL.md
+++ b/sunpump-skill/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: SunPump Trading
+description: Buy and sell meme tokens on SunPump, the TRON bonding-curve launchpad.
+version: 1.0.0
+dependencies:
+  - node >= 18.0.0
+  - tronweb
+tags:
+  - defi
+  - meme
+  - tron
+  - sunpump
+  - bonding-curve
+---
+
+# SunPump Trading Skill
+
+Trade meme tokens on **SunPump** — the leading fair-launch bonding-curve platform on TRON. This skill lets AI agents check prices, buy tokens, sell tokens, and inspect balances using helper scripts that interact with the SunPump smart contract (`TTfvyrAz86hbZk5iDpKD78pqLGgi8C7AAw`).
+
+> [!NOTE]
+> SunPump tokens trade on a **bonding curve** until they reach ~$69,420 market cap, at which point they automatically migrate to SunSwap V2. This skill only handles bonding-curve trading. If a token has migrated, use the **SunSwap** skill instead.
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+1. **Node.js 18+** and **npm** installed.
+2. Install dependencies:
+   ```bash
+   cd sunpump && npm install
+   ```
+3. Set environment variables:
+   ```bash
+   export TRON_PRIVATE_KEY="<your-private-key>"
+   export TRON_NETWORK="mainnet"          # or "nile" for testnet
+   export TRONGRID_API_KEY="<optional>"   # recommended for mainnet
+   ```
+
+> [!CAUTION]
+> **Never display or log the private key.** Environment variables must be set by the user before invoking any script.
+
+---
+
+## Available Scripts
+
+All scripts live in `sunpump/scripts/` and output structured JSON to **stdout**. Human-readable progress messages go to **stderr**.
+
+### 1. `balance.js` — Check Balances
+
+| Parameter | Required | Description |
+|---|---|---|
+| `tokenAddress` | No | TRC20 token address. Omit to show TRX only. |
+| `walletAddress` | No | Wallet to query. Defaults to configured wallet. |
+
+```bash
+# TRX balance only
+node scripts/balance.js
+
+# Token + TRX balance
+node scripts/balance.js TTokenAddress123
+
+# Token balance for a different wallet
+node scripts/balance.js TTokenAddress123 TWalletAddress456
+```
+
+**Output fields:** `wallet`, `trx_balance`, `token_balance`, `sunpump_approved`
+
+---
+
+### 2. `price.js` — Token Price & Trade Estimates
+
+| Parameter | Required | Description |
+|---|---|---|
+| `tokenAddress` | **Yes** | SunPump token address |
+| `--buy <trxAmount>` | No | Estimate tokens received for a TRX amount |
+| `--sell <tokenAmount>` | No | Estimate TRX received for selling tokens |
+
+```bash
+# Basic price and state
+node scripts/price.js TTokenAddress123
+
+# Price + buy estimate for 100 TRX
+node scripts/price.js TTokenAddress123 --buy 100
+
+# Price + sell estimate for 50000 tokens
+node scripts/price.js TTokenAddress123 --sell 50000
+```
+
+**Output fields:** `price_trx`, `state`, `state_label`, `buy_estimate`, `sell_estimate`
+
+---
+
+### 3. `buy.js` — Purchase Tokens
+
+| Parameter | Required | Description |
+|---|---|---|
+| `tokenAddress` | **Yes** | SunPump token address |
+| `trxAmount` | **Yes** | TRX to spend (human-readable, e.g. `100`) |
+| `--slippage <pct>` | No | Slippage tolerance, default `5` (percent) |
+| `--dry-run` | No | Estimate only, do not send transaction |
+
+```bash
+# Dry run — estimate only
+node scripts/buy.js TTokenAddress123 100 --dry-run
+
+# Execute with default 5% slippage
+node scripts/buy.js TTokenAddress123 100
+
+# Execute with 10% slippage (for volatile tokens)
+node scripts/buy.js TTokenAddress123 50 --slippage 10
+```
+
+**Output fields:** `expected_tokens`, `min_tokens_with_slippage`, `fee_trx`, `status`, `tx_id`
+
+---
+
+### 4. `sell.js` — Sell Tokens
+
+| Parameter | Required | Description |
+|---|---|---|
+| `tokenAddress` | **Yes** | SunPump token address |
+| `tokenAmount` | **Yes** | Tokens to sell (human-readable) or `all` |
+| `--slippage <pct>` | No | Slippage tolerance, default `5` (percent) |
+| `--dry-run` | No | Estimate only, do not send transaction |
+
+```bash
+# Dry run — estimate only
+node scripts/sell.js TTokenAddress123 50000 --dry-run
+
+# Sell specific amount
+node scripts/sell.js TTokenAddress123 50000
+
+# Sell entire balance with 10% slippage
+node scripts/sell.js TTokenAddress123 all --slippage 10
+```
+
+**Output fields:** `expected_trx`, `min_trx_with_slippage`, `fee_trx`, `status`, `tx_id`, `approve_tx`
+
+> [!NOTE]
+> The sell script automatically handles TRC20 approval. If the SunPump contract is not yet approved to spend the token, the script sends an `approve` transaction first, then waits before executing the sale.
+
+---
+
+## Usage Patterns
+
+### Pattern 1: Quick Quote (Recommended First Step)
+
+Always show the user a price estimate before executing a trade.
+
+```bash
+node scripts/price.js TTokenAddress123 --buy 100
+```
+
+Then confirm with the user before proceeding to `buy.js`.
+
+### Pattern 2: Two-Step Confirmation (Recommended for AI Agents)
+
+1. **Estimate:**
+   ```bash
+   node scripts/buy.js TTokenAddress123 100 --dry-run
+   ```
+2. **Show the estimate to the user and ask for confirmation.**
+3. **Execute:**
+   ```bash
+   node scripts/buy.js TTokenAddress123 100
+   ```
+
+### Pattern 3: Full Pre-Trade Checklist
+
+1. Check balance:
+   ```bash
+   node scripts/balance.js
+   ```
+2. Get price and estimate:
+   ```bash
+   node scripts/price.js TTokenAddress123 --buy 100
+   ```
+3. Dry-run the trade:
+   ```bash
+   node scripts/buy.js TTokenAddress123 100 --dry-run
+   ```
+4. Confirm with user, then execute:
+   ```bash
+   node scripts/buy.js TTokenAddress123 100
+   ```
+
+---
+
+## Recommended Workflow for AI Agents
+
+When a user asks to trade on SunPump, follow this sequence:
+
+1. **Confirm the token address.** Ask the user for the exact contract address if they only give a name or symbol.
+2. **Check price and state** with `price.js`. If `state` is `1` (migrated), inform the user and suggest using the SunSwap skill.
+3. **Show a quote** using `--dry-run` or `price.js --buy`/`--sell`. Present the expected amount, fee, and slippage to the user.
+4. **Get explicit confirmation** before executing any transaction.
+5. **Execute** the trade and report the transaction ID.
+6. **Verify** the result by checking the balance after the trade.
+
+---
+
+## Security Rules
+
+> [!CAUTION]
+> These rules are mandatory and must never be bypassed.
+
+1. **Never display private keys** in output or logs.
+2. **Never execute a trade without user confirmation.** Always show the estimate first.
+3. **Prevent duplicate transactions.** Do not retry a submitted transaction unless the user explicitly requests it.
+4. **Validate token addresses.** Ensure the address is a valid TRON base58 address starting with `T`.
+5. **Check token state before trading.** Only trade tokens in state `0` (bonding curve active). Direct the user to SunSwap for migrated tokens.
+6. **Warn about high slippage.** If slippage exceeds 10%, warn the user about the risk before proceeding.
+7. **Never send TRX to the SunPump contract directly.** Always use the `purchaseToken` function via the scripts.
+
+---
+
+## Script Output Format
+
+All scripts follow the same output convention:
+
+- **stdout** — Structured JSON (parsed by the agent)
+- **stderr** — Human-readable log messages (shown to the user)
+
+Example JSON output from `buy.js --dry-run`:
+
+```json
+{
+  "action": "buy",
+  "token": "TTokenAddress123",
+  "trx_amount": "100",
+  "expected_tokens": "1523456.789",
+  "min_tokens_with_slippage": "1447283.949",
+  "fee_trx": "1",
+  "slippage_percent": 5,
+  "dry_run": true,
+  "status": "dry_run"
+}
+```
+
+---
+
+## SunPump Key Facts
+
+| Property | Value |
+|---|---|
+| Launcher contract | `TTfvyrAz86hbZk5iDpKD78pqLGgi8C7AAw` |
+| Trading fee | 1% on buys and sells |
+| Token creation fee | 20 TRX |
+| Token decimals | 18 (standard for SunPump meme tokens) |
+| TRX decimals | 6 (1 TRX = 1,000,000 SUN) |
+| Bonding curve cap | ~$69,420 market cap |
+| Post-migration | Tokens move to SunSwap V2 with ~100k TRX liquidity |
+| Network | TRON Mainnet / Nile Testnet |
+
+---
+
+## Common Issues
+
+| Problem | Cause | Solution |
+|---|---|---|
+| `TRON_PRIVATE_KEY environment variable is required` | Env var not set | User must set `export TRON_PRIVATE_KEY="..."` |
+| `Token has migrated to SunSwap` | Token completed bonding curve | Use the **SunSwap** skill for trading |
+| `Transaction failed: OUT_OF_ENERGY` | Insufficient energy/bandwidth | Stake TRX for Energy or ensure enough TRX for bandwidth |
+| `Approval failed` | Token contract rejected approve | Check if the token address is correct |
+| `Cannot find module 'tronweb'` | Dependencies not installed | Run `npm install` in the sunpump directory |
+| Unexpectedly low token amount | High slippage or price movement | Use `--dry-run` first; increase slippage if needed |
+
+---
+
+## User Communication Protocol
+
+### Before Trade
+> "I'll check the current price of token `<address>` on SunPump and show you an estimate before executing anything."
+
+### Showing Quote
+> "Here's the estimate for buying with **X TRX**:
+> - Expected tokens: **Y**
+> - Fee: **Z TRX** (1%)
+> - Slippage protection: **W%**
+>
+> Shall I proceed with this trade?"
+
+### After Trade
+> "Transaction submitted! TX ID: `<txid>`
+> You can verify it on [Tronscan](https://tronscan.org/#/transaction/<txid>).
+> Let me check your updated balance..."
+
+### On Error
+> "The transaction failed: `<error message>`. This might be due to `<likely cause>`. Would you like me to try again with different parameters?"
+
+---
+
+## Resources
+
+- **Contract config:** `resources/sunpump_contracts.json` — addresses, ABIs, and notes
+- **SunPump platform:** https://sunpump.meme
+- **SUN.io developer docs:** https://docs.sun.io/DEVELOPERS/Sunpump/SunpumpFunctions
+- **Tronscan explorer:** https://tronscan.org
+
+---
+
+## Troubleshooting
+
+### Module installation
+```bash
+cd sunpump && npm install
+```
+
+### Network errors
+- Check that `TRON_NETWORK` is set correctly (`mainnet` or `nile`).
+- If rate-limited, set `TRONGRID_API_KEY`.
+
+### Transaction failures
+- Ensure sufficient TRX balance for trade amount + gas.
+- For sells, the script handles approval automatically. If approval fails, check the token address.
+- Use `--dry-run` to verify parameters before executing.
+
+### Self-transfer validation
+- The scripts will reject attempts to send tokens to yourself.
+- If you need to move tokens between your own wallets, use a direct TRC20 transfer instead.
+
+---
+
+*Version 1.0.0 — Created by [M2M Agent Registry](https://m2mregistry.io) for Bank of AI*

--- a/sunpump-skill/SKILL.md
+++ b/sunpump-skill/SKILL.md
@@ -29,7 +29,7 @@ Trade meme tokens on **SunPump** — the leading fair-launch bonding-curve platf
 1. **Node.js 18+** and **npm** installed.
 2. Install dependencies:
    ```bash
-   cd sunpump && npm install
+   cd sunpump-skill && npm install
    ```
 3. Set environment variables:
    ```bash
@@ -45,7 +45,7 @@ Trade meme tokens on **SunPump** — the leading fair-launch bonding-curve platf
 
 ## Available Scripts
 
-All scripts live in `sunpump/scripts/` and output structured JSON to **stdout**. Human-readable progress messages go to **stderr**.
+All scripts live in `sunpump-skill/scripts/` and output structured JSON to **stdout**. Human-readable progress messages go to **stderr**.
 
 ### 1. `balance.js` — Check Balances
 
@@ -309,7 +309,7 @@ Example JSON output from `buy.js --dry-run`:
 | `Token has migrated to SunSwap` | Token completed bonding curve | Use the **SunSwap** skill for trading |
 | `Transaction failed: OUT_OF_ENERGY` | Insufficient energy/bandwidth | Stake TRX for Energy or ensure enough TRX for bandwidth |
 | `Approval failed` | Token contract rejected approve | Check if the token address is correct |
-| `Cannot find module 'tronweb'` | Dependencies not installed | Run `npm install` in the sunpump directory |
+| `Cannot find module 'tronweb'` | Dependencies not installed | Run `npm install` in the sunpump-skill directory |
 | Unexpectedly low token amount | High slippage or price movement | Use `--dry-run` first; increase slippage if needed |
 
 ---
@@ -350,7 +350,7 @@ Example JSON output from `buy.js --dry-run`:
 
 ### Module installation
 ```bash
-cd sunpump && npm install
+cd sunpump-skill && npm install
 ```
 
 ### Network errors

--- a/sunpump-skill/package-lock.json
+++ b/sunpump-skill/package-lock.json
@@ -1,0 +1,553 @@
+{
+  "name": "@bankofai/sunpump-skill",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@bankofai/sunpump-skill",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "tronweb": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.4.0",
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ethereum-cryptography": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
+      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.4.2",
+        "@noble/hashes": "1.4.0",
+        "@scure/bip32": "1.4.0",
+        "@scure/bip39": "1.3.0"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.13.5",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.5.tgz",
+      "integrity": "sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/google-protobuf": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tronweb": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/tronweb/-/tronweb-6.2.2.tgz",
+      "integrity": "sha512-jRBf4+7fJ0HUVzveBi0tE21r3EygCNtbYE92T38Sxlwr/x320W2vz+dvGLOIpp4kW/CvJ4HLvtnb6U30A0V2eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "7.26.10",
+        "axios": "1.13.5",
+        "bignumber.js": "9.1.2",
+        "ethereum-cryptography": "2.2.1",
+        "ethers": "6.13.5",
+        "eventemitter3": "5.0.1",
+        "google-protobuf": "3.21.4",
+        "semver": "7.7.1",
+        "validator": "13.15.23"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/validator": {
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/sunpump-skill/package.json
+++ b/sunpump-skill/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@bankofai/sunpump-skill",
+  "version": "1.0.0",
+  "description": "SunPump bonding-curve trading skill for AI agents on TRON",
+  "license": "MIT",
+  "private": true,
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "tronweb": "^6.0.0"
+  }
+}

--- a/sunpump-skill/resources/sunpump_contracts.json
+++ b/sunpump-skill/resources/sunpump_contracts.json
@@ -1,0 +1,174 @@
+{
+  "networks": {
+    "mainnet": {
+      "sunpump_launcher": {
+        "address": "TTfvyrAz86hbZk5iDpKD78pqLGgi8C7AAw",
+        "description": "SunPump bonding-curve launcher — handles token creation, purchase, and sale"
+      },
+      "sunswap_v2_router": {
+        "address": "TKzxdSv2FZKQrEqkKVgp5DcwEXBEKMg2Ax",
+        "description": "SunSwap V2 router — tokens migrate here after bonding curve completes"
+      },
+      "trongrid_api": "https://api.trongrid.io"
+    },
+    "nile": {
+      "sunpump_launcher": {
+        "address": "TTfvyrAz86hbZk5iDpKD78pqLGgi8C7AAw",
+        "description": "SunPump launcher on Nile testnet (verify before use)"
+      },
+      "trongrid_api": "https://nile.trongrid.io"
+    }
+  },
+  "abi": {
+    "purchaseToken": {
+      "type": "function",
+      "name": "purchaseToken",
+      "inputs": [
+        { "name": "token", "type": "address" },
+        { "name": "minTokensExpected", "type": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable",
+      "description": "Buy tokens by sending TRX as callValue. minTokensExpected provides slippage protection."
+    },
+    "saleToken": {
+      "type": "function",
+      "name": "saleToken",
+      "inputs": [
+        { "name": "token", "type": "address" },
+        { "name": "tokenAmount", "type": "uint256" },
+        { "name": "amountMin", "type": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "description": "Sell tokens for TRX. amountMin is minimum TRX to receive (slippage protection). Requires token approval first."
+    },
+    "getPrice": {
+      "type": "function",
+      "name": "getPrice",
+      "inputs": [
+        { "name": "token", "type": "address" }
+      ],
+      "outputs": [
+        { "name": "price", "type": "uint256" }
+      ],
+      "stateMutability": "view",
+      "description": "Returns current token price on the bonding curve."
+    },
+    "getTokenState": {
+      "type": "function",
+      "name": "getTokenState",
+      "inputs": [
+        { "name": "token", "type": "address" }
+      ],
+      "outputs": [
+        { "name": "state", "type": "uint256" }
+      ],
+      "stateMutability": "view",
+      "description": "Returns token lifecycle state (0=active on bonding curve, 1=migrated to SunSwap)."
+    },
+    "getTokenAmountByPurchaseWithFee": {
+      "type": "function",
+      "name": "getTokenAmountByPurchaseWithFee",
+      "inputs": [
+        { "name": "token", "type": "address" },
+        { "name": "trxAmount", "type": "uint256" }
+      ],
+      "outputs": [
+        { "name": "tokenAmount", "type": "uint256" },
+        { "name": "fee", "type": "uint256" }
+      ],
+      "stateMutability": "view",
+      "description": "Estimate tokens received and fee for a given TRX purchase amount."
+    },
+    "getTrxAmountBySaleWithFee": {
+      "type": "function",
+      "name": "getTrxAmountBySaleWithFee",
+      "inputs": [
+        { "name": "token", "type": "address" },
+        { "name": "tokenAmount", "type": "uint256" }
+      ],
+      "outputs": [
+        { "name": "trxAmount", "type": "uint256" },
+        { "name": "fee", "type": "uint256" }
+      ],
+      "stateMutability": "view",
+      "description": "Estimate TRX received and fee for selling a given token amount."
+    },
+    "getExactTrxAmountForSaleWithFee": {
+      "type": "function",
+      "name": "getExactTrxAmountForSaleWithFee",
+      "inputs": [
+        { "name": "token", "type": "address" },
+        { "name": "trxAmount", "type": "uint256" }
+      ],
+      "outputs": [
+        { "name": "tokenAmount", "type": "uint256" },
+        { "name": "fee", "type": "uint256" }
+      ],
+      "stateMutability": "view",
+      "description": "Calculate tokens needed to sell to receive an exact TRX amount."
+    },
+    "createAndInitPurchase": {
+      "type": "function",
+      "name": "createAndInitPurchase",
+      "inputs": [
+        { "name": "name", "type": "string" },
+        { "name": "symbol", "type": "string" },
+        { "name": "description", "type": "string" },
+        { "name": "tokenURI", "type": "string" },
+        { "name": "minTokensExpected", "type": "uint256" }
+      ],
+      "outputs": [],
+      "stateMutability": "payable",
+      "description": "Create a new meme token and optionally make an initial purchase. Requires mint fee (20 TRX) + optional purchase TRX as callValue."
+    },
+    "approve": {
+      "type": "function",
+      "name": "approve",
+      "inputs": [
+        { "name": "spender", "type": "address" },
+        { "name": "amount", "type": "uint256" }
+      ],
+      "outputs": [
+        { "name": "", "type": "bool" }
+      ],
+      "stateMutability": "nonpayable",
+      "description": "Standard TRC20 approve — must be called on the TOKEN contract (not SunPump) before selling."
+    },
+    "balanceOf": {
+      "type": "function",
+      "name": "balanceOf",
+      "inputs": [
+        { "name": "account", "type": "address" }
+      ],
+      "outputs": [
+        { "name": "", "type": "uint256" }
+      ],
+      "stateMutability": "view",
+      "description": "Standard TRC20 balanceOf — call on the TOKEN contract to check holdings."
+    },
+    "allowance": {
+      "type": "function",
+      "name": "allowance",
+      "inputs": [
+        { "name": "owner", "type": "address" },
+        { "name": "spender", "type": "address" }
+      ],
+      "outputs": [
+        { "name": "", "type": "uint256" }
+      ],
+      "stateMutability": "view",
+      "description": "Standard TRC20 allowance — check how much the SunPump contract can spend."
+    }
+  },
+  "notes": {
+    "trading_fee": "1% fee on all buys and sells on the bonding curve",
+    "token_decimals": "SunPump meme tokens typically use 18 decimals",
+    "trx_decimals": "TRX uses 6 decimals (1 TRX = 1,000,000 SUN)",
+    "bonding_curve_cap": "Bonding curve completes at ~$69,420 market cap, then tokens migrate to SunSwap V2",
+    "mint_fee": "Creating a token costs 20 TRX",
+    "approval_before_sell": "You MUST approve the SunPump launcher contract to spend your tokens before calling saleToken",
+    "slippage": "Always use slippage protection (minTokensExpected / amountMin). Recommended: 1-5% for stable trades, up to 10-15% for volatile new tokens"
+  }
+}

--- a/sunpump-skill/resources/sunpump_contracts.json
+++ b/sunpump-skill/resources/sunpump_contracts.json
@@ -72,7 +72,7 @@
         { "name": "state", "type": "uint256" }
       ],
       "stateMutability": "view",
-      "description": "Returns token lifecycle state (0=active on bonding curve, 1=migrated to SunSwap)."
+      "description": "Returns token lifecycle state (0=not registered, 1=active on bonding curve, 2=pending migration, 3=migrated to SunSwap V2)."
     },
     "getTokenAmountByPurchaseWithFee": {
       "type": "function",

--- a/sunpump-skill/resources/sunpump_contracts.json
+++ b/sunpump-skill/resources/sunpump_contracts.json
@@ -1,4 +1,11 @@
 {
+  "slippage": {
+    "default_percent": 5,
+    "min_percent": 0.1,
+    "max_percent": 50,
+    "warn_above_percent": 10,
+    "description": "Slippage tolerance controls the minimum acceptable output for a trade. Values above warn_above_percent trigger a warning. Values outside min/max are rejected."
+  },
   "networks": {
     "mainnet": {
       "sunpump_launcher": {

--- a/sunpump-skill/scripts/balance.js
+++ b/sunpump-skill/scripts/balance.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+/**
+ * balance.js — Check TRX and SunPump token balances.
+ *
+ * Usage:
+ *   node balance.js                          # TRX balance of configured wallet
+ *   node balance.js <tokenAddress>           # token balance of configured wallet
+ *   node balance.js <tokenAddress> <wallet>  # token balance of specified wallet
+ *
+ * Environment:
+ *   TRON_PRIVATE_KEY   — wallet private key (required)
+ *   TRON_NETWORK       — mainnet (default) | nile
+ *   TRONGRID_API_KEY   — optional TronGrid API key
+ */
+
+const {
+  CONTRACTS,
+  TOKEN_DECIMALS,
+  TRX_DECIMALS,
+  getTronWeb,
+  getLauncherAddress,
+  fromSun,
+  outputJSON,
+  log,
+} = require("./utils");
+
+async function main() {
+  const args = process.argv.slice(2);
+  const tronWeb = getTronWeb();
+  const walletAddress =
+    args[1] || tronWeb.defaultAddress.base58;
+
+  log(`Checking balances for ${walletAddress} ...`);
+
+  // TRX balance
+  const trxBalanceSun = await tronWeb.trx.getBalance(walletAddress);
+  const result = {
+    wallet: walletAddress,
+    trx_balance: fromSun(trxBalanceSun, TRX_DECIMALS),
+    trx_balance_raw: String(trxBalanceSun),
+  };
+
+  // Token balance (if specified)
+  if (args[0]) {
+    const tokenAddress = args[0];
+    const tokenContract = await tronWeb.contract(
+      [CONTRACTS.abi.balanceOf],
+      tokenAddress
+    );
+    const tokenBalance = await tokenContract.balanceOf(walletAddress).call();
+    result.token = tokenAddress;
+    result.token_balance = fromSun(tokenBalance, TOKEN_DECIMALS);
+    result.token_balance_raw = String(tokenBalance);
+
+    // Check allowance to SunPump
+    const launcherAddr = getLauncherAddress();
+    const allowanceContract = await tronWeb.contract(
+      [CONTRACTS.abi.allowance],
+      tokenAddress
+    );
+    const allowance = await allowanceContract
+      .allowance(walletAddress, launcherAddr)
+      .call();
+    result.sunpump_allowance_raw = String(allowance);
+    result.sunpump_approved = BigInt(allowance) > 0n;
+
+    log(
+      `Token balance: ${result.token_balance} | Approved for SunPump: ${result.sunpump_approved}`
+    );
+  }
+
+  log(`TRX balance: ${result.trx_balance} TRX`);
+  outputJSON(result);
+}
+
+main().catch((err) => {
+  outputJSON({ error: err.message });
+  process.exit(1);
+});

--- a/sunpump-skill/scripts/balance.js
+++ b/sunpump-skill/scripts/balance.js
@@ -9,7 +9,7 @@
  *   node balance.js <tokenAddress> <wallet>  # token balance of specified wallet
  *
  * Environment:
- *   TRON_PRIVATE_KEY   — wallet private key (required)
+ *   TRON_PRIVATE_KEY   — wallet private key (required when no wallet address provided)
  *   TRON_NETWORK       — mainnet (default) | nile
  *   TRONGRID_API_KEY   — optional TronGrid API key
  */
@@ -19,6 +19,7 @@ const {
   TOKEN_DECIMALS,
   TRX_DECIMALS,
   getTronWeb,
+  getTronWebReadOnly,
   getLauncherAddress,
   fromSun,
   outputJSON,
@@ -27,9 +28,9 @@ const {
 
 async function main() {
   const args = process.argv.slice(2);
-  const tronWeb = getTronWeb();
-  const walletAddress =
-    args[1] || tronWeb.defaultAddress.base58;
+  const explicitWallet = args[1];
+  const tronWeb = explicitWallet ? getTronWebReadOnly() : getTronWeb();
+  const walletAddress = explicitWallet || tronWeb.defaultAddress.base58;
 
   log(`Checking balances for ${walletAddress} ...`);
 

--- a/sunpump-skill/scripts/buy.js
+++ b/sunpump-skill/scripts/buy.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+/**
+ * buy.js — Purchase tokens on SunPump bonding curve.
+ *
+ * Usage:
+ *   node buy.js <tokenAddress> <trxAmount> [--slippage <percent>] [--dry-run]
+ *
+ * Arguments:
+ *   tokenAddress   — TRC20 address of the SunPump token
+ *   trxAmount      — amount of TRX to spend (human-readable, e.g. "100")
+ *   --slippage     — slippage tolerance in percent (default: 5)
+ *   --dry-run      — only estimate, do not execute
+ *
+ * Environment:
+ *   TRON_PRIVATE_KEY   — wallet private key (required)
+ *   TRON_NETWORK       — mainnet (default) | nile
+ *   TRONGRID_API_KEY   — optional TronGrid API key
+ */
+
+const {
+  CONTRACTS,
+  TOKEN_DECIMALS,
+  TRX_DECIMALS,
+  getTronWeb,
+  getLauncherAddress,
+  toSun,
+  fromSun,
+  applySlippage,
+  outputJSON,
+  log,
+} = require("./utils");
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error(
+      "Usage: node buy.js <tokenAddress> <trxAmount> [--slippage <pct>] [--dry-run]"
+    );
+    process.exit(1);
+  }
+
+  const tokenAddress = args[0];
+  const trxAmountHuman = args[1];
+  const slippageIdx = args.indexOf("--slippage");
+  const slippage =
+    slippageIdx !== -1 ? parseFloat(args[slippageIdx + 1]) : 5;
+  const dryRun = args.includes("--dry-run");
+
+  const tronWeb = getTronWeb();
+  const launcherAddr = getLauncherAddress();
+  const trxAmountSun = toSun(trxAmountHuman, TRX_DECIMALS);
+
+  log(`Preparing to buy token ${tokenAddress} with ${trxAmountHuman} TRX ...`);
+
+  // Step 1: Check token state
+  const launcher = await tronWeb.contract(
+    [
+      CONTRACTS.abi.getTokenState,
+      CONTRACTS.abi.getTokenAmountByPurchaseWithFee,
+      CONTRACTS.abi.purchaseToken,
+    ],
+    launcherAddr
+  );
+
+  const state = await launcher.getTokenState(tokenAddress).call();
+  if (Number(state) !== 0) {
+    outputJSON({
+      error: "Token has migrated to SunSwap. Use SunSwap skill to trade.",
+      state: Number(state),
+    });
+    process.exit(1);
+  }
+
+  // Step 2: Get estimate
+  const est = await launcher
+    .getTokenAmountByPurchaseWithFee(tokenAddress, String(trxAmountSun))
+    .call();
+
+  const expectedTokens = String(est.tokenAmount);
+  const minTokens = String(applySlippage(expectedTokens, slippage));
+
+  const result = {
+    action: "buy",
+    token: tokenAddress,
+    trx_amount: trxAmountHuman,
+    trx_amount_raw: String(trxAmountSun),
+    expected_tokens: fromSun(expectedTokens, TOKEN_DECIMALS),
+    expected_tokens_raw: expectedTokens,
+    min_tokens_with_slippage: fromSun(minTokens, TOKEN_DECIMALS),
+    min_tokens_raw: minTokens,
+    fee_trx: fromSun(est.fee, TRX_DECIMALS),
+    slippage_percent: slippage,
+    dry_run: dryRun,
+  };
+
+  log(
+    `Estimate: ${result.expected_tokens} tokens (min: ${result.min_tokens_with_slippage} with ${slippage}% slippage)`
+  );
+  log(`Fee: ${result.fee_trx} TRX`);
+
+  if (dryRun) {
+    result.status = "dry_run";
+    log("Dry run — no transaction sent.");
+    outputJSON(result);
+    return;
+  }
+
+  // Step 3: Execute purchase
+  log("Sending purchaseToken transaction ...");
+  try {
+    const tx = await launcher
+      .purchaseToken(tokenAddress, minTokens)
+      .send({
+        callValue: Number(trxAmountSun),
+        feeLimit: 150_000_000,
+        shouldPollResponse: false,
+      });
+
+    result.status = "submitted";
+    result.tx_id = tx;
+    log(`Transaction submitted: ${tx}`);
+  } catch (err) {
+    result.status = "failed";
+    result.error = err.message || String(err);
+    log(`Transaction failed: ${result.error}`);
+  }
+
+  outputJSON(result);
+}
+
+main().catch((err) => {
+  outputJSON({ error: err.message });
+  process.exit(1);
+});

--- a/sunpump-skill/scripts/buy.js
+++ b/sunpump-skill/scripts/buy.js
@@ -66,16 +66,24 @@ async function main() {
   );
 
   const state = await launcher.getTokenState(tokenAddress).call();
-  if (Number(state) !== 0) {
+  const stateNum = Number(state);
+  if (stateNum !== 1) {
     const sunswapRouter = CONTRACTS.networks[(process.env.TRON_NETWORK || "mainnet").toLowerCase()].sunswap_v2_router;
+    const stateLabels = { 0: "not registered", 2: "pending migration", 3: "migrated (SunSwap V2)" };
+    const label = stateLabels[stateNum] || `unknown (${stateNum})`;
     outputJSON({
-      error: "Token has migrated to SunSwap V2. The bonding curve is closed.",
-      state: Number(state),
-      migration: {
-        reason: "Token reached the ~$69,420 market cap threshold and liquidity was moved to SunSwap V2.",
-        sunswap_router: sunswapRouter ? sunswapRouter.address : null,
-        action: "Use the SunSwap skill to trade this token. The SunPump bonding-curve scripts will not work for migrated tokens.",
-      },
+      error: stateNum === 3
+        ? "Token has migrated to SunSwap V2. The bonding curve is closed."
+        : `Token is not active on the bonding curve (state: ${label}).`,
+      state: stateNum,
+      state_label: label,
+      ...(stateNum === 3 && {
+        migration: {
+          reason: "Token reached the ~$69,420 market cap threshold and liquidity was moved to SunSwap V2.",
+          sunswap_router: sunswapRouter ? sunswapRouter.address : null,
+          action: "Use the SunSwap skill to trade this token. The SunPump bonding-curve scripts will not work for migrated tokens.",
+        },
+      }),
     });
     process.exit(1);
   }

--- a/sunpump-skill/scripts/buy.js
+++ b/sunpump-skill/scripts/buy.js
@@ -20,12 +20,14 @@
 
 const {
   CONTRACTS,
+  SLIPPAGE,
   TOKEN_DECIMALS,
   TRX_DECIMALS,
   getTronWeb,
   getLauncherAddress,
   toSun,
   fromSun,
+  validateSlippage,
   applySlippage,
   outputJSON,
   log,
@@ -43,8 +45,8 @@ async function main() {
   const tokenAddress = args[0];
   const trxAmountHuman = args[1];
   const slippageIdx = args.indexOf("--slippage");
-  const slippage =
-    slippageIdx !== -1 ? parseFloat(args[slippageIdx + 1]) : 5;
+  const slippageArg = slippageIdx !== -1 ? parseFloat(args[slippageIdx + 1]) : undefined;
+  const slippage = validateSlippage(slippageArg);
   const dryRun = args.includes("--dry-run");
 
   const tronWeb = getTronWeb();
@@ -65,9 +67,15 @@ async function main() {
 
   const state = await launcher.getTokenState(tokenAddress).call();
   if (Number(state) !== 0) {
+    const sunswapRouter = CONTRACTS.networks[(process.env.TRON_NETWORK || "mainnet").toLowerCase()].sunswap_v2_router;
     outputJSON({
-      error: "Token has migrated to SunSwap. Use SunSwap skill to trade.",
+      error: "Token has migrated to SunSwap V2. The bonding curve is closed.",
       state: Number(state),
+      migration: {
+        reason: "Token reached the ~$69,420 market cap threshold and liquidity was moved to SunSwap V2.",
+        sunswap_router: sunswapRouter ? sunswapRouter.address : null,
+        action: "Use the SunSwap skill to trade this token. The SunPump bonding-curve scripts will not work for migrated tokens.",
+      },
     });
     process.exit(1);
   }

--- a/sunpump-skill/scripts/price.js
+++ b/sunpump-skill/scripts/price.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+/**
+ * price.js — Query SunPump token price, state, and trade estimates.
+ *
+ * Usage:
+ *   node price.js <tokenAddress>                     # basic price + state
+ *   node price.js <tokenAddress> --buy  <trxAmount>   # estimate buy
+ *   node price.js <tokenAddress> --sell <tokenAmount>  # estimate sell
+ *
+ * Environment:
+ *   TRON_PRIVATE_KEY   — wallet private key (required by TronWeb)
+ *   TRON_NETWORK       — mainnet (default) | nile
+ *   TRONGRID_API_KEY   — optional TronGrid API key
+ */
+
+const {
+  CONTRACTS,
+  TOKEN_DECIMALS,
+  TRX_DECIMALS,
+  getTronWeb,
+  getLauncherAddress,
+  toSun,
+  fromSun,
+  outputJSON,
+  log,
+} = require("./utils");
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 1) {
+    console.error(
+      "Usage: node price.js <tokenAddress> [--buy <trxAmount>] [--sell <tokenAmount>]"
+    );
+    process.exit(1);
+  }
+
+  const tokenAddress = args[0];
+  const tronWeb = getTronWeb();
+  const launcherAddr = getLauncherAddress();
+
+  log(`Querying SunPump for token ${tokenAddress} ...`);
+
+  const launcher = await tronWeb.contract(
+    [
+      CONTRACTS.abi.getPrice,
+      CONTRACTS.abi.getTokenState,
+      CONTRACTS.abi.getTokenAmountByPurchaseWithFee,
+      CONTRACTS.abi.getTrxAmountBySaleWithFee,
+    ],
+    launcherAddr
+  );
+
+  // Basic price and state
+  const [price, state] = await Promise.all([
+    launcher.getPrice(tokenAddress).call(),
+    launcher.getTokenState(tokenAddress).call(),
+  ]);
+
+  const stateLabels = { 0: "active (bonding curve)", 1: "migrated (SunSwap)" };
+  const result = {
+    token: tokenAddress,
+    price_raw: String(price),
+    price_trx: fromSun(price, TRX_DECIMALS),
+    state: Number(state),
+    state_label: stateLabels[Number(state)] || `unknown (${state})`,
+  };
+
+  // Optional buy estimate
+  const buyIdx = args.indexOf("--buy");
+  if (buyIdx !== -1 && args[buyIdx + 1]) {
+    const trxAmount = toSun(args[buyIdx + 1], TRX_DECIMALS);
+    const est = await launcher
+      .getTokenAmountByPurchaseWithFee(tokenAddress, String(trxAmount))
+      .call();
+    result.buy_estimate = {
+      trx_in: args[buyIdx + 1],
+      tokens_out: fromSun(est.tokenAmount, TOKEN_DECIMALS),
+      tokens_out_raw: String(est.tokenAmount),
+      fee_raw: String(est.fee),
+      fee_trx: fromSun(est.fee, TRX_DECIMALS),
+    };
+    log(
+      `Buy estimate: ${args[buyIdx + 1]} TRX -> ${result.buy_estimate.tokens_out} tokens (fee: ${result.buy_estimate.fee_trx} TRX)`
+    );
+  }
+
+  // Optional sell estimate
+  const sellIdx = args.indexOf("--sell");
+  if (sellIdx !== -1 && args[sellIdx + 1]) {
+    const tokenAmount = toSun(args[sellIdx + 1], TOKEN_DECIMALS);
+    const est = await launcher
+      .getTrxAmountBySaleWithFee(tokenAddress, String(tokenAmount))
+      .call();
+    result.sell_estimate = {
+      tokens_in: args[sellIdx + 1],
+      trx_out: fromSun(est.trxAmount, TRX_DECIMALS),
+      trx_out_raw: String(est.trxAmount),
+      fee_raw: String(est.fee),
+      fee_trx: fromSun(est.fee, TRX_DECIMALS),
+    };
+    log(
+      `Sell estimate: ${args[sellIdx + 1]} tokens -> ${result.sell_estimate.trx_out} TRX (fee: ${result.sell_estimate.fee_trx} TRX)`
+    );
+  }
+
+  outputJSON(result);
+}
+
+main().catch((err) => {
+  outputJSON({ error: err.message });
+  process.exit(1);
+});

--- a/sunpump-skill/scripts/price.js
+++ b/sunpump-skill/scripts/price.js
@@ -58,16 +58,17 @@ async function main() {
     launcher.getTokenState(tokenAddress).call(),
   ]);
 
-  const stateLabels = { 0: "active (bonding curve)", 1: "migrated (SunSwap V2)" };
+  const stateNum = Number(state);
+  const stateLabels = { 0: "not registered", 1: "active (bonding curve)", 2: "pending migration", 3: "migrated (SunSwap V2)" };
   const result = {
     token: tokenAddress,
     price_raw: String(price),
     price_trx: fromSun(price, TRX_DECIMALS),
-    state: Number(state),
-    state_label: stateLabels[Number(state)] || `unknown (${state})`,
+    state: stateNum,
+    state_label: stateLabels[stateNum] || `unknown (${stateNum})`,
   };
 
-  if (Number(state) !== 0) {
+  if (stateNum === 3) {
     const sunswapRouter = CONTRACTS.networks[NETWORK].sunswap_v2_router;
     result.migration = {
       reason: "Token reached the ~$69,420 market cap threshold and liquidity was moved to SunSwap V2.",
@@ -75,6 +76,8 @@ async function main() {
       action: "Use the SunSwap skill to trade this token.",
     };
     log("WARNING: This token has migrated to SunSwap V2. Bonding-curve trading is no longer available.");
+  } else if (stateNum !== 1) {
+    log(`WARNING: Token state is "${stateLabels[stateNum] || stateNum}" — bonding-curve trading may not be available.`);
   }
 
   // Optional buy estimate

--- a/sunpump-skill/scripts/price.js
+++ b/sunpump-skill/scripts/price.js
@@ -26,6 +26,8 @@ const {
   log,
 } = require("./utils");
 
+const NETWORK = (process.env.TRON_NETWORK || "mainnet").toLowerCase();
+
 async function main() {
   const args = process.argv.slice(2);
   if (args.length < 1) {
@@ -57,7 +59,7 @@ async function main() {
     launcher.getTokenState(tokenAddress).call(),
   ]);
 
-  const stateLabels = { 0: "active (bonding curve)", 1: "migrated (SunSwap)" };
+  const stateLabels = { 0: "active (bonding curve)", 1: "migrated (SunSwap V2)" };
   const result = {
     token: tokenAddress,
     price_raw: String(price),
@@ -65,6 +67,16 @@ async function main() {
     state: Number(state),
     state_label: stateLabels[Number(state)] || `unknown (${state})`,
   };
+
+  if (Number(state) !== 0) {
+    const sunswapRouter = CONTRACTS.networks[NETWORK].sunswap_v2_router;
+    result.migration = {
+      reason: "Token reached the ~$69,420 market cap threshold and liquidity was moved to SunSwap V2.",
+      sunswap_router: sunswapRouter ? sunswapRouter.address : null,
+      action: "Use the SunSwap skill to trade this token.",
+    };
+    log("WARNING: This token has migrated to SunSwap V2. Bonding-curve trading is no longer available.");
+  }
 
   // Optional buy estimate
   const buyIdx = args.indexOf("--buy");

--- a/sunpump-skill/scripts/price.js
+++ b/sunpump-skill/scripts/price.js
@@ -9,7 +9,6 @@
  *   node price.js <tokenAddress> --sell <tokenAmount>  # estimate sell
  *
  * Environment:
- *   TRON_PRIVATE_KEY   — wallet private key (required by TronWeb)
  *   TRON_NETWORK       — mainnet (default) | nile
  *   TRONGRID_API_KEY   — optional TronGrid API key
  */
@@ -18,7 +17,7 @@ const {
   CONTRACTS,
   TOKEN_DECIMALS,
   TRX_DECIMALS,
-  getTronWeb,
+  getTronWebReadOnly,
   getLauncherAddress,
   toSun,
   fromSun,
@@ -38,7 +37,7 @@ async function main() {
   }
 
   const tokenAddress = args[0];
-  const tronWeb = getTronWeb();
+  const tronWeb = getTronWebReadOnly();
   const launcherAddr = getLauncherAddress();
 
   log(`Querying SunPump for token ${tokenAddress} ...`);

--- a/sunpump-skill/scripts/sell.js
+++ b/sunpump-skill/scripts/sell.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+/**
+ * sell.js — Sell SunPump tokens back for TRX via the bonding curve.
+ *
+ * Usage:
+ *   node sell.js <tokenAddress> <tokenAmount> [--slippage <percent>] [--dry-run]
+ *   node sell.js <tokenAddress> all [--slippage <percent>] [--dry-run]
+ *
+ * Arguments:
+ *   tokenAddress   — TRC20 address of the SunPump token
+ *   tokenAmount    — amount of tokens to sell (human-readable) or "all"
+ *   --slippage     — slippage tolerance in percent (default: 5)
+ *   --dry-run      — only estimate, do not execute
+ *
+ * Environment:
+ *   TRON_PRIVATE_KEY   — wallet private key (required)
+ *   TRON_NETWORK       — mainnet (default) | nile
+ *   TRONGRID_API_KEY   — optional TronGrid API key
+ */
+
+const {
+  CONTRACTS,
+  TOKEN_DECIMALS,
+  TRX_DECIMALS,
+  MAX_UINT256,
+  getTronWeb,
+  getLauncherAddress,
+  toSun,
+  fromSun,
+  applySlippage,
+  outputJSON,
+  log,
+} = require("./utils");
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error(
+      "Usage: node sell.js <tokenAddress> <tokenAmount|all> [--slippage <pct>] [--dry-run]"
+    );
+    process.exit(1);
+  }
+
+  const tokenAddress = args[0];
+  const tokenAmountArg = args[1];
+  const slippageIdx = args.indexOf("--slippage");
+  const slippage =
+    slippageIdx !== -1 ? parseFloat(args[slippageIdx + 1]) : 5;
+  const dryRun = args.includes("--dry-run");
+
+  const tronWeb = getTronWeb();
+  const launcherAddr = getLauncherAddress();
+  const walletAddress = tronWeb.defaultAddress.base58;
+
+  log(`Preparing to sell token ${tokenAddress} ...`);
+
+  // Step 1: Check token state
+  const launcher = await tronWeb.contract(
+    [
+      CONTRACTS.abi.getTokenState,
+      CONTRACTS.abi.getTrxAmountBySaleWithFee,
+      CONTRACTS.abi.saleToken,
+    ],
+    launcherAddr
+  );
+
+  const state = await launcher.getTokenState(tokenAddress).call();
+  if (Number(state) !== 0) {
+    outputJSON({
+      error: "Token has migrated to SunSwap. Use SunSwap skill to trade.",
+      state: Number(state),
+    });
+    process.exit(1);
+  }
+
+  // Step 2: Determine token amount
+  const tokenContract = await tronWeb.contract(
+    [CONTRACTS.abi.balanceOf, CONTRACTS.abi.allowance, CONTRACTS.abi.approve],
+    tokenAddress
+  );
+
+  let tokenAmountRaw;
+  if (tokenAmountArg.toLowerCase() === "all") {
+    tokenAmountRaw = String(await tokenContract.balanceOf(walletAddress).call());
+    if (tokenAmountRaw === "0") {
+      outputJSON({ error: "Token balance is zero. Nothing to sell." });
+      process.exit(1);
+    }
+    log(`Selling full balance: ${fromSun(tokenAmountRaw, TOKEN_DECIMALS)} tokens`);
+  } else {
+    tokenAmountRaw = String(toSun(tokenAmountArg, TOKEN_DECIMALS));
+  }
+
+  // Step 3: Get sale estimate
+  const est = await launcher
+    .getTrxAmountBySaleWithFee(tokenAddress, tokenAmountRaw)
+    .call();
+
+  const expectedTrx = String(est.trxAmount);
+  const minTrx = String(applySlippage(expectedTrx, slippage));
+
+  const result = {
+    action: "sell",
+    token: tokenAddress,
+    token_amount:
+      tokenAmountArg.toLowerCase() === "all"
+        ? fromSun(tokenAmountRaw, TOKEN_DECIMALS)
+        : tokenAmountArg,
+    token_amount_raw: tokenAmountRaw,
+    expected_trx: fromSun(expectedTrx, TRX_DECIMALS),
+    expected_trx_raw: expectedTrx,
+    min_trx_with_slippage: fromSun(minTrx, TRX_DECIMALS),
+    min_trx_raw: minTrx,
+    fee_trx: fromSun(est.fee, TRX_DECIMALS),
+    slippage_percent: slippage,
+    dry_run: dryRun,
+  };
+
+  log(
+    `Estimate: ${result.expected_trx} TRX (min: ${result.min_trx_with_slippage} with ${slippage}% slippage)`
+  );
+  log(`Fee: ${result.fee_trx} TRX`);
+
+  if (dryRun) {
+    result.status = "dry_run";
+    log("Dry run — no transaction sent.");
+    outputJSON(result);
+    return;
+  }
+
+  // Step 4: Check and set allowance
+  const currentAllowance = await tokenContract
+    .allowance(walletAddress, launcherAddr)
+    .call();
+
+  if (BigInt(currentAllowance) < BigInt(tokenAmountRaw)) {
+    log("Approving SunPump to spend tokens ...");
+    try {
+      const approveTx = await tokenContract
+        .approve(launcherAddr, MAX_UINT256)
+        .send({ feeLimit: 50_000_000, shouldPollResponse: false });
+      result.approve_tx = approveTx;
+      log(`Approval submitted: ${approveTx}`);
+      // Wait for approval to propagate
+      log("Waiting for approval confirmation ...");
+      await new Promise((r) => setTimeout(r, 4000));
+    } catch (err) {
+      result.status = "approval_failed";
+      result.error = err.message || String(err);
+      log(`Approval failed: ${result.error}`);
+      outputJSON(result);
+      return;
+    }
+  } else {
+    log("Allowance already sufficient.");
+  }
+
+  // Step 5: Execute sale
+  log("Sending saleToken transaction ...");
+  try {
+    const tx = await launcher
+      .saleToken(tokenAddress, tokenAmountRaw, minTrx)
+      .send({ feeLimit: 150_000_000, shouldPollResponse: false });
+
+    result.status = "submitted";
+    result.tx_id = tx;
+    log(`Transaction submitted: ${tx}`);
+  } catch (err) {
+    result.status = "failed";
+    result.error = err.message || String(err);
+    log(`Transaction failed: ${result.error}`);
+  }
+
+  outputJSON(result);
+}
+
+main().catch((err) => {
+  outputJSON({ error: err.message });
+  process.exit(1);
+});

--- a/sunpump-skill/scripts/sell.js
+++ b/sunpump-skill/scripts/sell.js
@@ -21,6 +21,7 @@
 
 const {
   CONTRACTS,
+  SLIPPAGE,
   TOKEN_DECIMALS,
   TRX_DECIMALS,
   MAX_UINT256,
@@ -28,6 +29,7 @@ const {
   getLauncherAddress,
   toSun,
   fromSun,
+  validateSlippage,
   applySlippage,
   outputJSON,
   log,
@@ -45,8 +47,8 @@ async function main() {
   const tokenAddress = args[0];
   const tokenAmountArg = args[1];
   const slippageIdx = args.indexOf("--slippage");
-  const slippage =
-    slippageIdx !== -1 ? parseFloat(args[slippageIdx + 1]) : 5;
+  const slippageArg = slippageIdx !== -1 ? parseFloat(args[slippageIdx + 1]) : undefined;
+  const slippage = validateSlippage(slippageArg);
   const dryRun = args.includes("--dry-run");
 
   const tronWeb = getTronWeb();
@@ -67,9 +69,15 @@ async function main() {
 
   const state = await launcher.getTokenState(tokenAddress).call();
   if (Number(state) !== 0) {
+    const sunswapRouter = CONTRACTS.networks[(process.env.TRON_NETWORK || "mainnet").toLowerCase()].sunswap_v2_router;
     outputJSON({
-      error: "Token has migrated to SunSwap. Use SunSwap skill to trade.",
+      error: "Token has migrated to SunSwap V2. The bonding curve is closed.",
       state: Number(state),
+      migration: {
+        reason: "Token reached the ~$69,420 market cap threshold and liquidity was moved to SunSwap V2.",
+        sunswap_router: sunswapRouter ? sunswapRouter.address : null,
+        action: "Use the SunSwap skill to trade this token. The SunPump bonding-curve scripts will not work for migrated tokens.",
+      },
     });
     process.exit(1);
   }

--- a/sunpump-skill/scripts/sell.js
+++ b/sunpump-skill/scripts/sell.js
@@ -68,16 +68,24 @@ async function main() {
   );
 
   const state = await launcher.getTokenState(tokenAddress).call();
-  if (Number(state) !== 0) {
+  const stateNum = Number(state);
+  if (stateNum !== 1) {
     const sunswapRouter = CONTRACTS.networks[(process.env.TRON_NETWORK || "mainnet").toLowerCase()].sunswap_v2_router;
+    const stateLabels = { 0: "not registered", 2: "pending migration", 3: "migrated (SunSwap V2)" };
+    const label = stateLabels[stateNum] || `unknown (${stateNum})`;
     outputJSON({
-      error: "Token has migrated to SunSwap V2. The bonding curve is closed.",
-      state: Number(state),
-      migration: {
-        reason: "Token reached the ~$69,420 market cap threshold and liquidity was moved to SunSwap V2.",
-        sunswap_router: sunswapRouter ? sunswapRouter.address : null,
-        action: "Use the SunSwap skill to trade this token. The SunPump bonding-curve scripts will not work for migrated tokens.",
-      },
+      error: stateNum === 3
+        ? "Token has migrated to SunSwap V2. The bonding curve is closed."
+        : `Token is not active on the bonding curve (state: ${label}).`,
+      state: stateNum,
+      state_label: label,
+      ...(stateNum === 3 && {
+        migration: {
+          reason: "Token reached the ~$69,420 market cap threshold and liquidity was moved to SunSwap V2.",
+          sunswap_router: sunswapRouter ? sunswapRouter.address : null,
+          action: "Use the SunSwap skill to trade this token. The SunPump bonding-curve scripts will not work for migrated tokens.",
+        },
+      }),
     });
     process.exit(1);
   }

--- a/sunpump-skill/scripts/utils.js
+++ b/sunpump-skill/scripts/utils.js
@@ -1,0 +1,112 @@
+/**
+ * Shared utilities for SunPump skill scripts.
+ */
+
+const { TronWeb } = require("tronweb");
+const path = require("path");
+const fs = require("fs");
+
+const CONTRACTS = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname, "..", "resources", "sunpump_contracts.json"),
+    "utf-8"
+  )
+);
+
+const TRX_DECIMALS = 6;
+const TOKEN_DECIMALS = 18;
+const MAX_UINT256 =
+  "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+
+/**
+ * Build a TronWeb instance from environment variables.
+ */
+function getTronWeb() {
+  const network = (process.env.TRON_NETWORK || "mainnet").toLowerCase();
+  const net = CONTRACTS.networks[network];
+  if (!net) {
+    throw new Error(
+      `Unknown network "${network}". Supported: ${Object.keys(CONTRACTS.networks).join(", ")}`
+    );
+  }
+
+  const fullHost = net.trongrid_api;
+  const privateKey = process.env.TRON_PRIVATE_KEY;
+  if (!privateKey) {
+    throw new Error("TRON_PRIVATE_KEY environment variable is required");
+  }
+
+  const opts = { fullHost, privateKey };
+  if (process.env.TRONGRID_API_KEY) {
+    opts.headers = { "TRON-PRO-API-KEY": process.env.TRONGRID_API_KEY };
+  }
+
+  return new TronWeb(opts);
+}
+
+/**
+ * Return the SunPump launcher address for the active network.
+ */
+function getLauncherAddress() {
+  const network = (process.env.TRON_NETWORK || "mainnet").toLowerCase();
+  return CONTRACTS.networks[network].sunpump_launcher.address;
+}
+
+/**
+ * Convert a human-readable amount to on-chain integer (sun/wei).
+ */
+function toSun(amount, decimals = TRX_DECIMALS) {
+  const parts = String(amount).split(".");
+  const whole = parts[0] || "0";
+  let frac = (parts[1] || "").slice(0, decimals).padEnd(decimals, "0");
+  return BigInt(whole) * BigInt(10 ** decimals) + BigInt(frac);
+}
+
+/**
+ * Convert an on-chain integer to human-readable string.
+ */
+function fromSun(raw, decimals = TRX_DECIMALS) {
+  const str = String(raw).padStart(decimals + 1, "0");
+  const whole = str.slice(0, str.length - decimals) || "0";
+  const frac = str.slice(str.length - decimals).replace(/0+$/, "");
+  return frac ? `${whole}.${frac}` : whole;
+}
+
+/**
+ * Apply slippage to an amount. Returns the minimum acceptable amount.
+ * @param {bigint|string} amount - The expected amount.
+ * @param {number} slippagePercent - e.g. 5 for 5%.
+ */
+function applySlippage(amount, slippagePercent) {
+  const raw = BigInt(amount);
+  const factor = BigInt(Math.round((100 - slippagePercent) * 100));
+  return (raw * factor) / 10000n;
+}
+
+/**
+ * Output structured JSON to stdout (for agent consumption).
+ */
+function outputJSON(data) {
+  process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+}
+
+/**
+ * Log human-readable messages to stderr (visible to user, not parsed by agent).
+ */
+function log(msg) {
+  process.stderr.write(msg + "\n");
+}
+
+module.exports = {
+  CONTRACTS,
+  TRX_DECIMALS,
+  TOKEN_DECIMALS,
+  MAX_UINT256,
+  getTronWeb,
+  getLauncherAddress,
+  toSun,
+  fromSun,
+  applySlippage,
+  outputJSON,
+  log,
+};

--- a/sunpump-skill/scripts/utils.js
+++ b/sunpump-skill/scripts/utils.js
@@ -17,6 +17,7 @@ const TRX_DECIMALS = 6;
 const TOKEN_DECIMALS = 18;
 const MAX_UINT256 =
   "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+const SLIPPAGE = CONTRACTS.slippage;
 
 /**
  * Build a TronWeb instance from environment variables.
@@ -73,6 +74,27 @@ function fromSun(raw, decimals = TRX_DECIMALS) {
 }
 
 /**
+ * Validate and resolve slippage. Returns the effective slippage percent.
+ * Rejects values outside the configured [min, max] range.
+ * Logs a warning for values above warn_above_percent.
+ * @param {number|undefined} slippagePercent — user-supplied value, or undefined for default.
+ * @returns {number} effective slippage percent.
+ */
+function validateSlippage(slippagePercent) {
+  const pct = slippagePercent != null ? slippagePercent : SLIPPAGE.default_percent;
+  if (pct < SLIPPAGE.min_percent || pct > SLIPPAGE.max_percent) {
+    outputJSON({
+      error: `Slippage ${pct}% is outside the allowed range [${SLIPPAGE.min_percent}%, ${SLIPPAGE.max_percent}%]. Adjust your --slippage value.`,
+    });
+    process.exit(1);
+  }
+  if (pct > SLIPPAGE.warn_above_percent) {
+    log(`WARNING: Slippage is set to ${pct}%, which exceeds the recommended maximum of ${SLIPPAGE.warn_above_percent}%. Proceed with caution.`);
+  }
+  return pct;
+}
+
+/**
  * Apply slippage to an amount. Returns the minimum acceptable amount.
  * @param {bigint|string} amount - The expected amount.
  * @param {number} slippagePercent - e.g. 5 for 5%.
@@ -99,6 +121,7 @@ function log(msg) {
 
 module.exports = {
   CONTRACTS,
+  SLIPPAGE,
   TRX_DECIMALS,
   TOKEN_DECIMALS,
   MAX_UINT256,
@@ -106,6 +129,7 @@ module.exports = {
   getLauncherAddress,
   toSun,
   fromSun,
+  validateSlippage,
   applySlippage,
   outputJSON,
   log,

--- a/sunpump-skill/scripts/utils.js
+++ b/sunpump-skill/scripts/utils.js
@@ -46,6 +46,33 @@ function getTronWeb() {
 }
 
 /**
+ * Build a read-only TronWeb instance (no private key required).
+ * Use this for queries that only read on-chain data (e.g. price, state).
+ */
+function getTronWebReadOnly() {
+  const network = (process.env.TRON_NETWORK || "mainnet").toLowerCase();
+  const net = CONTRACTS.networks[network];
+  if (!net) {
+    throw new Error(
+      `Unknown network "${network}". Supported: ${Object.keys(CONTRACTS.networks).join(", ")}`
+    );
+  }
+
+  const fullHost = net.trongrid_api;
+  const opts = { fullHost };
+  if (process.env.TRONGRID_API_KEY) {
+    opts.headers = { "TRON-PRO-API-KEY": process.env.TRONGRID_API_KEY };
+  }
+
+  const tw = new TronWeb(opts);
+  tw.defaultAddress = {
+    hex: "410000000000000000000000000000000000000000",
+    base58: "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb",
+  };
+  return tw;
+}
+
+/**
  * Return the SunPump launcher address for the active network.
  */
 function getLauncherAddress() {
@@ -126,6 +153,7 @@ module.exports = {
   TOKEN_DECIMALS,
   MAX_UINT256,
   getTronWeb,
+  getTronWebReadOnly,
   getLauncherAddress,
   toSun,
   fromSun,


### PR DESCRIPTION
## Summary
- Adds `sunpump-skill` for buying and selling meme tokens on SunPump (TRON bonding-curve launchpad)
- Tokens priced via bonding curve, auto-migrate to SunSwap V2 at ~$69,420 market cap
- Check token balances and current bonding curve prices
- Buy and sell tokens with slippage protection

## Scripts
- `balance.js` — Check token balances
- `price.js` — Query current bonding curve prices
- `buy.js` — Buy tokens on the bonding curve
- `sell.js` — Sell tokens back to the curve

Source: https://github.com/M2M-TRC8004-Registry/sunpump-skill