### PR TITLE
Add USDD / JUST Protocol skill

### DIFF
--- a/usdd-skill/.gitignore
+++ b/usdd-skill/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/usdd-skill/.gitignore
+++ b/usdd-skill/.gitignore
@@ -1,2 +1,1 @@
 node_modules/
-package-lock.json

--- a/usdd-skill/README.md
+++ b/usdd-skill/README.md
@@ -1,0 +1,27 @@
+# USDD / JUST Protocol
+
+> USDD stablecoin operations — PSM swaps, vault position queries, and balance checks via the JUST Protocol on TRON.
+
+## Scripts
+
+- `psm-swap.js` — Buy/sell USDT via PSM at 1:1 (zero fee)
+- `psm-info.js` — PSM state: fees, USDT reserves, USDD supply
+- `balance.js` — Check USDD, USDT, USDC, TRX, and JST balances
+- `vault-info.js` — Vault (CDP) parameters and individual position queries
+
+## Quick Start
+
+```bash
+cd usdd-skill && npm install
+export TRON_PRIVATE_KEY="<key>"
+
+node scripts/psm-info.js
+node scripts/balance.js
+node scripts/psm-swap.js sell 1000 --dry-run
+node scripts/vault-info.js
+```
+
+## Dependencies
+
+- Node.js 18+
+- [tronweb](https://www.npmjs.com/package/tronweb) ^6.0.0

--- a/usdd-skill/SKILL.md
+++ b/usdd-skill/SKILL.md
@@ -143,7 +143,8 @@ node scripts/vault-info.js --cdp 42               # Check specific CDP position
 |---|---|---|
 | USDD Token (v2) | `TXDk8mbtRbXeYuMNS83CfKPaYYT8XWv9Hz` | USDD TRC20 (18 decimals) |
 | UsddPsm | `TBXW4hS5KYjjbJXDpnrPf4zhkLwrpUjbyz` | PSM — buyGem/sellGem for 1:1 swaps |
-| PSM GemJoin | `TSUYvQ5tdd3DijCD1uGunGLpftHuSZ12sQ` | PSM USDT collateral adapter |
+| PSM GemJoin | `TSUYvQ5tdd3DijCD1uGunGLpftHuSZ12sQ` | PSM USDT collateral adapter (sellGem: approve USDT here) |
+| UsddJoin | `TUajR7CbXU6hX8n3XtNkitFAD25JvP99K6` | USDD join adapter (buyGem: approve USDD here) |
 | DssCdpManager | `TDDWjmQaquEtUn1Pa8wCd8dfWFPdQLGPYL` | CDP management (open, frob, flux) |
 | Vat | `TH5dhX7o39afSbfDT2e3c9k4itWjNKD4D9` | Core accounting engine |
 | USDT Token | `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` | USDT TRC20 (6 decimals) |

--- a/usdd-skill/SKILL.md
+++ b/usdd-skill/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: USDD / JUST Protocol
+description: USDD stablecoin operations — PSM swaps (buyGem/sellGem), vault position queries, and balance checks via the JUST Protocol on TRON.
+version: 1.0.0
+dependencies:
+  - node >= 18.0.0
+  - tronweb
+tags:
+  - defi
+  - stablecoin
+  - tron
+  - usdd
+  - vault
+  - cdp
+  - just
+  - psm
+---
+
+# USDD / JUST Protocol
+
+Interact with **USDD**, TRON's over-collateralized stablecoin, via the JUST Protocol. Swap USDT for USDD at 1:1 through the Peg Stability Module (PSM), query vault (CDP) positions and protocol parameters, and check token balances.
+
+---
+
+## Quick Start
+
+```bash
+cd usdd-skill && npm install
+export TRON_PRIVATE_KEY="<your-private-key>"
+export TRON_NETWORK="mainnet"
+```
+
+> [!CAUTION]
+> **Never display or log the private key.**
+
+---
+
+## Available Scripts
+
+### 1. `psm-swap.js` — Buy/Sell USDT via PSM (1:1, Zero Fee)
+
+```bash
+node scripts/psm-swap.js sell 1000 --dry-run    # Preview: 1000 USDT -> 1000 USDD
+node scripts/psm-swap.js sell 500                # Execute: sell 500 USDT for USDD
+node scripts/psm-swap.js buy 1000 --dry-run      # Preview: spend USDD -> 1000 USDT
+node scripts/psm-swap.js buy 250                 # Execute: buy 250 USDT with USDD
+```
+
+- `sell <amount>`: Sell USDT to PSM, receive USDD 1:1
+- `buy <amount>`: Buy USDT from PSM, spend USDD 1:1
+- Amount is always in USDT terms
+- Auto-handles TRC20 approval
+- Uses the direct `buyGem`/`sellGem` PSM interface (not the router)
+
+> [!NOTE]
+> PSM fees (`tin`/`tout`) are currently **0%**. Use `psm-info.js` to verify current fees.
+
+**Output:** `action`, `direction`, `amount_usdt`, `status`, `tx_id`, `needs_approval`
+
+### 2. `psm-info.js` — PSM State (Read-Only)
+
+```bash
+node scripts/psm-info.js
+```
+
+**No private key required.** Shows PSM fees (tin/tout), USDT reserves held by the GemJoin, and USDD total supply.
+
+**Output:** `fees` (tin, tout, percentages), `reserves` (usdt_available), `usdd` (total_supply)
+
+### 3. `balance.js` — Check Token Balances
+
+```bash
+node scripts/balance.js
+node scripts/balance.js --address TXYzL2gqz5AB4dbGeiX9h8unkKHxuWwb
+```
+
+Queries balances for USDD, USDT, USDC, TRX, and JST. Uses `--address` for read-only lookups (no private key needed).
+
+**Output:** `wallet`, `balances[]` (symbol, balance, address)
+
+### 4. `vault-info.js` — Vault Positions & Parameters (Read-Only)
+
+```bash
+node scripts/vault-info.js                      # All vault types
+node scripts/vault-info.js --vault TRX-A        # Specific vault type
+node scripts/vault-info.js --cdp 42             # Specific CDP position
+```
+
+**No private key required.** Queries the Vat and DssCdpManager for vault parameters and individual CDP positions.
+
+Without `--cdp`: shows global parameters per vault type (total debt, rate, spot price, debt ceiling, dust).
+
+With `--cdp <id>`: shows a specific CDP's collateral locked, debt, and collateralization ratio.
+
+**Output (global):** `vaults[]` (name, total_debt_usdd, rate, spot, debt_ceiling_usdd)
+
+**Output (CDP):** `cdp_id`, `owner`, `collateral_locked`, `actual_debt_usdd`, `collateralization_ratio`
+
+---
+
+## Usage Patterns
+
+### Get USDD via PSM (Simplest)
+
+```bash
+node scripts/psm-info.js                         # Check PSM reserves and fees
+node scripts/psm-swap.js sell 1000 --dry-run      # Preview swap
+node scripts/psm-swap.js sell 1000                # Execute: 1000 USDT -> 1000 USDD
+```
+
+### Redeem USDD for USDT
+
+```bash
+node scripts/balance.js                           # Check USDD balance
+node scripts/psm-swap.js buy 500 --dry-run        # Preview redemption
+node scripts/psm-swap.js buy 500                  # Execute: spend USDD -> 500 USDT
+```
+
+### Inspect Vault Health
+
+```bash
+node scripts/vault-info.js                        # View all vault type parameters
+node scripts/vault-info.js --cdp 42               # Check specific CDP position
+```
+
+---
+
+## Supported Vaults
+
+| Name | Collateral | GemJoin Address | Stability Fee |
+|---|---|---|---|
+| TRX-A | TRX | `TJ1VWPvFVq7sVsN7J7dWJVZz4SLT14qRUr` | 5% |
+| TRX-B | TRX | `TGQKnHDQNyc3QeHJ7YxH8wggdg89UVXyvX` | 5% |
+| TRX-C | TRX | `TPUPPLTYLdbW4jxwD5g2T7ystxsR9HL2mt` | 5% |
+| sTRX-A | sTRX | `TKha7zcAXZMaaWzoVmUHtvVFqr9GeiChgJ` | 1% |
+| USDT-A | USDT | `TDUkQbjrXs6xUbxGCLknWwJHxVTdysXBhy` | 0% |
+
+---
+
+## Key Contracts
+
+| Contract | Address | Description |
+|---|---|---|
+| USDD Token (v2) | `TXDk8mbtRbXeYuMNS83CfKPaYYT8XWv9Hz` | USDD TRC20 (18 decimals) |
+| UsddPsm | `TBXW4hS5KYjjbJXDpnrPf4zhkLwrpUjbyz` | PSM — buyGem/sellGem for 1:1 swaps |
+| PSM GemJoin | `TSUYvQ5tdd3DijCD1uGunGLpftHuSZ12sQ` | PSM USDT collateral adapter |
+| DssCdpManager | `TDDWjmQaquEtUn1Pa8wCd8dfWFPdQLGPYL` | CDP management (open, frob, flux) |
+| Vat | `TH5dhX7o39afSbfDT2e3c9k4itWjNKD4D9` | Core accounting engine |
+| USDT Token | `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` | USDT TRC20 (6 decimals) |
+| JST Token | `TCFLL5dx5ZJdKnWuesXxi1VPwjLVmWZZy9` | JUST governance token (18 decimals) |
+
+---
+
+## Security Rules
+
+1. **Never display private keys.**
+2. **Always dry-run before PSM swaps.** Verify amounts and token directions.
+3. **Check PSM reserves before swapping.** If USDT reserves are low, buyGem may fail.
+4. **Decimal mismatch awareness.** USDD is 18 decimals, USDT/USDC are 6. Scripts handle normalization automatically.
+5. **Vault positions are read-only.** This skill queries but does not modify vault positions (no deposit/draw/repay/withdraw).
+6. **Verify CDP IDs.** Always confirm the CDP ID and owner before acting on position data.
+
+---
+
+## Common Issues
+
+| Problem | Solution |
+|---|---|
+| `Unknown token` | Use USDD, USDT, USDC, TRX, or JST |
+| `Insufficient balance` | Check wallet balance with `balance.js` before swapping |
+| PSM swap fails | PSM may be depleted — check reserves with `psm-info.js` |
+| `Unknown vault` | Use TRX-A, TRX-B, TRX-C, sTRX-A, or USDT-A |
+| `Unknown network` | Set `TRON_NETWORK` to mainnet, nile, or shasta |
+| Vault shows all zeros | The ilk may not be active on this network, or the CDP ID does not exist |
+
+---
+
+*Version 1.0.0 — Created by [M2M Agent Registry](https://m2mregistry.io) for Bank of AI*

--- a/usdd-skill/package-lock.json
+++ b/usdd-skill/package-lock.json
@@ -1,0 +1,553 @@
+{
+  "name": "@bankofai/usdd-skill",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@bankofai/usdd-skill",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "tronweb": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.4.0",
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ethereum-cryptography": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
+      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.4.2",
+        "@noble/hashes": "1.4.0",
+        "@scure/bip32": "1.4.0",
+        "@scure/bip39": "1.3.0"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.13.5",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.5.tgz",
+      "integrity": "sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/google-protobuf": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tronweb": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/tronweb/-/tronweb-6.2.2.tgz",
+      "integrity": "sha512-jRBf4+7fJ0HUVzveBi0tE21r3EygCNtbYE92T38Sxlwr/x320W2vz+dvGLOIpp4kW/CvJ4HLvtnb6U30A0V2eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "7.26.10",
+        "axios": "1.13.5",
+        "bignumber.js": "9.1.2",
+        "ethereum-cryptography": "2.2.1",
+        "ethers": "6.13.5",
+        "eventemitter3": "5.0.1",
+        "google-protobuf": "3.21.4",
+        "semver": "7.7.1",
+        "validator": "13.15.23"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/validator": {
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/usdd-skill/package.json
+++ b/usdd-skill/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@bankofai/usdd-skill",
+  "version": "1.0.0",
+  "description": "USDD vault (CDP) positions and PSM swaps via JUST Protocol on TRON",
+  "license": "MIT",
+  "private": true,
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "tronweb": "^6.0.0"
+  }
+}

--- a/usdd-skill/resources/usdd_contracts.json
+++ b/usdd-skill/resources/usdd_contracts.json
@@ -1,0 +1,341 @@
+{
+  "tokens": {
+    "mainnet": {
+      "USDD": {
+        "address": "TXDk8mbtRbXeYuMNS83CfKPaYYT8XWv9Hz",
+        "symbol": "USDD",
+        "decimals": 18
+      },
+      "USDD_V1": {
+        "address": "TPYmHEhy5n8TCEfYGqW2rPxsghSfzghPDn",
+        "symbol": "USDD_V1",
+        "decimals": 18
+      },
+      "USDT": {
+        "address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+        "symbol": "USDT",
+        "decimals": 6
+      },
+      "USDC": {
+        "address": "TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8",
+        "symbol": "USDC",
+        "decimals": 6
+      },
+      "TRX": {
+        "address": null,
+        "symbol": "TRX",
+        "decimals": 6,
+        "is_native": true
+      },
+      "JST": {
+        "address": "TCFLL5dx5ZJdKnWuesXxi1VPwjLVmWZZy9",
+        "symbol": "JST",
+        "decimals": 18
+      }
+    }
+  },
+  "vaults": {
+    "mainnet": [
+      {
+        "name": "TRX-A",
+        "gemJoin": "TJ1VWPvFVq7sVsN7J7dWJVZz4SLT14qRUr",
+        "collateral": "TRX",
+        "collateral_decimals": 6,
+        "stability_fee_pct": 5,
+        "is_native": true
+      },
+      {
+        "name": "TRX-B",
+        "gemJoin": "TGQKnHDQNyc3QeHJ7YxH8wggdg89UVXyvX",
+        "collateral": "TRX",
+        "collateral_decimals": 6,
+        "stability_fee_pct": 5,
+        "is_native": true
+      },
+      {
+        "name": "TRX-C",
+        "gemJoin": "TPUPPLTYLdbW4jxwD5g2T7ystxsR9HL2mt",
+        "collateral": "TRX",
+        "collateral_decimals": 6,
+        "stability_fee_pct": 5,
+        "is_native": true
+      },
+      {
+        "name": "sTRX-A",
+        "gemJoin": "TKha7zcAXZMaaWzoVmUHtvVFqr9GeiChgJ",
+        "collateral": "sTRX",
+        "collateral_decimals": 18,
+        "stability_fee_pct": 1,
+        "is_native": false
+      },
+      {
+        "name": "USDT-A",
+        "gemJoin": "TDUkQbjrXs6xUbxGCLknWwJHxVTdysXBhy",
+        "collateral": "USDT",
+        "collateral_decimals": 6,
+        "stability_fee_pct": 0,
+        "is_native": false
+      }
+    ]
+  },
+  "contracts": {
+    "mainnet": {
+      "psm": {
+        "address": "TBXW4hS5KYjjbJXDpnrPf4zhkLwrpUjbyz",
+        "name": "UsddPsm",
+        "description": "Peg Stability Module — buyGem/sellGem for 1:1 USDT<->USDD swaps, zero fee"
+      },
+      "psmGemJoin": {
+        "address": "TSUYvQ5tdd3DijCD1uGunGLpftHuSZ12sQ",
+        "name": "PSM GemJoin (USDT)",
+        "description": "AuthGemJoin5 adapter for PSM USDT collateral. sellGem requires USDT approval here."
+      },
+      "usddJoin": {
+        "address": "TUajR7CbXU6hX8n3XtNkitFAD25JvP99K6",
+        "name": "UsddJoin",
+        "description": "USDD join adapter. buyGem requires USDD approval here (PSM calls usddJoin.join internally)."
+      },
+      "cdpManager": {
+        "address": "TDDWjmQaquEtUn1Pa8wCd8dfWFPdQLGPYL",
+        "name": "DssCdpManager",
+        "description": "CDP management — open, frob, flux, move, give"
+      },
+      "vat": {
+        "address": "TH5dhX7o39afSbfDT2e3c9k4itWjNKD4D9",
+        "name": "Vat",
+        "description": "Core accounting engine — urns (vault positions) and ilks (vault type params)"
+      },
+      "proxyActions": {
+        "address": "TEk9usYZsunkc5oYijyMte6sGurspik2Js",
+        "name": "DssProxyActions",
+        "description": "Bundled vault operations (requires DSProxy to call via delegatecall)"
+      }
+    }
+  },
+  "abi": {
+    "psm": {
+      "buyGem": {
+        "type": "function",
+        "name": "buyGem",
+        "inputs": [
+          { "name": "usr", "type": "address" },
+          { "name": "gemAmt", "type": "uint256" }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+      },
+      "sellGem": {
+        "type": "function",
+        "name": "sellGem",
+        "inputs": [
+          { "name": "usr", "type": "address" },
+          { "name": "gemAmt", "type": "uint256" }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+      },
+      "tin": {
+        "type": "function",
+        "name": "tin",
+        "inputs": [],
+        "outputs": [{ "name": "", "type": "uint256" }],
+        "stateMutability": "view"
+      },
+      "tout": {
+        "type": "function",
+        "name": "tout",
+        "inputs": [],
+        "outputs": [{ "name": "", "type": "uint256" }],
+        "stateMutability": "view"
+      },
+      "gemJoin": {
+        "type": "function",
+        "name": "gemJoin",
+        "inputs": [],
+        "outputs": [{ "name": "", "type": "address" }],
+        "stateMutability": "view"
+      },
+      "vat": {
+        "type": "function",
+        "name": "vat",
+        "inputs": [],
+        "outputs": [{ "name": "", "type": "address" }],
+        "stateMutability": "view"
+      }
+    },
+    "cdpManager": {
+      "open": {
+        "type": "function",
+        "name": "open",
+        "inputs": [
+          { "name": "ilk", "type": "bytes32" },
+          { "name": "usr", "type": "address" }
+        ],
+        "outputs": [{ "name": "cdpId", "type": "uint256" }],
+        "stateMutability": "nonpayable"
+      },
+      "frob": {
+        "type": "function",
+        "name": "frob",
+        "inputs": [
+          { "name": "cdp", "type": "uint256" },
+          { "name": "dink", "type": "int256" },
+          { "name": "dart", "type": "int256" }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+      },
+      "flux": {
+        "type": "function",
+        "name": "flux",
+        "inputs": [
+          { "name": "cdp", "type": "uint256" },
+          { "name": "dst", "type": "address" },
+          { "name": "wad", "type": "uint256" }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+      },
+      "move": {
+        "type": "function",
+        "name": "move",
+        "inputs": [
+          { "name": "cdp", "type": "uint256" },
+          { "name": "dst", "type": "address" },
+          { "name": "rad", "type": "uint256" }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+      },
+      "urns": {
+        "type": "function",
+        "name": "urns",
+        "inputs": [{ "name": "cdp", "type": "uint256" }],
+        "outputs": [{ "name": "", "type": "address" }],
+        "stateMutability": "view"
+      },
+      "ilks": {
+        "type": "function",
+        "name": "ilks",
+        "inputs": [{ "name": "cdp", "type": "uint256" }],
+        "outputs": [{ "name": "", "type": "bytes32" }],
+        "stateMutability": "view"
+      },
+      "owns": {
+        "type": "function",
+        "name": "owns",
+        "inputs": [{ "name": "cdp", "type": "uint256" }],
+        "outputs": [{ "name": "", "type": "address" }],
+        "stateMutability": "view"
+      },
+      "cdpi": {
+        "type": "function",
+        "name": "cdpi",
+        "inputs": [],
+        "outputs": [{ "name": "", "type": "uint256" }],
+        "stateMutability": "view"
+      }
+    },
+    "vat": {
+      "urns": {
+        "type": "function",
+        "name": "urns",
+        "inputs": [
+          { "name": "ilk", "type": "bytes32" },
+          { "name": "urn", "type": "address" }
+        ],
+        "outputs": [
+          { "name": "ink", "type": "uint256" },
+          { "name": "art", "type": "uint256" }
+        ],
+        "stateMutability": "view"
+      },
+      "ilks": {
+        "type": "function",
+        "name": "ilks",
+        "inputs": [{ "name": "ilk", "type": "bytes32" }],
+        "outputs": [
+          { "name": "Art", "type": "uint256" },
+          { "name": "rate", "type": "uint256" },
+          { "name": "spot", "type": "uint256" },
+          { "name": "line", "type": "uint256" },
+          { "name": "dust", "type": "uint256" }
+        ],
+        "stateMutability": "view"
+      }
+    },
+    "gemJoin": {
+      "join": {
+        "type": "function",
+        "name": "join",
+        "inputs": [
+          { "name": "usr", "type": "address" },
+          { "name": "wad", "type": "uint256" }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+      },
+      "exit": {
+        "type": "function",
+        "name": "exit",
+        "inputs": [
+          { "name": "usr", "type": "address" },
+          { "name": "wad", "type": "uint256" }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+      }
+    },
+    "trc20": {
+      "balanceOf": {
+        "type": "function",
+        "name": "balanceOf",
+        "inputs": [{ "name": "owner", "type": "address" }],
+        "outputs": [{ "name": "", "type": "uint256" }],
+        "stateMutability": "view"
+      },
+      "approve": {
+        "type": "function",
+        "name": "approve",
+        "inputs": [
+          { "name": "spender", "type": "address" },
+          { "name": "amount", "type": "uint256" }
+        ],
+        "outputs": [{ "name": "", "type": "bool" }],
+        "stateMutability": "nonpayable"
+      },
+      "allowance": {
+        "type": "function",
+        "name": "allowance",
+        "inputs": [
+          { "name": "owner", "type": "address" },
+          { "name": "spender", "type": "address" }
+        ],
+        "outputs": [{ "name": "", "type": "uint256" }],
+        "stateMutability": "view"
+      },
+      "totalSupply": {
+        "type": "function",
+        "name": "totalSupply",
+        "inputs": [],
+        "outputs": [{ "name": "", "type": "uint256" }],
+        "stateMutability": "view"
+      },
+      "decimals": {
+        "type": "function",
+        "name": "decimals",
+        "inputs": [],
+        "outputs": [{ "name": "", "type": "uint8" }],
+        "stateMutability": "view"
+      }
+    }
+  },
+  "notes": {
+    "psm": "UsddPsm allows 1:1 swaps between USDD and USDT. buyGem(usr, gemAmt) = spend USDD, receive USDT. sellGem(usr, gemAmt) = spend USDT, receive USDD. gemAmt is in USDT decimals (6). Fees (tin/tout) are currently 0.",
+    "psm_approval": "For sellGem: approve PSM GemJoin to spend USDT. For buyGem: approve USDD to the PSM contract.",
+    "vaults": "MakerDAO-style CDP system. GemJoin adapters handle join/exit of collateral. DssCdpManager manages CDP lifecycle. Vat is the core accounting engine.",
+    "ilk_encoding": "Vault type names (TRX-A, TRX-B, etc.) are encoded as bytes32 using ethers-style left-padded UTF-8.",
+    "decimals": "USDD uses 18 decimals. USDT/USDC use 6 decimals. TRX uses 6 decimals. JST uses 18 decimals. Vat uses RAY (10^27) and WAD (10^18) precision.",
+    "vat_math": "Actual debt = art * rate / RAY. Collateral value = ink * spot. Collat ratio = (ink * spot) / (art * rate / RAY)."
+  }
+}

--- a/usdd-skill/resources/usdd_contracts.json
+++ b/usdd-skill/resources/usdd_contracts.json
@@ -332,7 +332,7 @@
   },
   "notes": {
     "psm": "UsddPsm allows 1:1 swaps between USDD and USDT. buyGem(usr, gemAmt) = spend USDD, receive USDT. sellGem(usr, gemAmt) = spend USDT, receive USDD. gemAmt is in USDT decimals (6). Fees (tin/tout) are currently 0.",
-    "psm_approval": "For sellGem: approve PSM GemJoin to spend USDT. For buyGem: approve USDD to the PSM contract.",
+    "psm_approval": "For sellGem: approve PSM GemJoin (psmGemJoin) to spend USDT. For buyGem: approve UsddJoin (usddJoin) to spend USDD.",
     "vaults": "MakerDAO-style CDP system. GemJoin adapters handle join/exit of collateral. DssCdpManager manages CDP lifecycle. Vat is the core accounting engine.",
     "ilk_encoding": "Vault type names (TRX-A, TRX-B, etc.) are encoded as bytes32 using ethers-style left-padded UTF-8.",
     "decimals": "USDD uses 18 decimals. USDT/USDC use 6 decimals. TRX uses 6 decimals. JST uses 18 decimals. Vat uses RAY (10^27) and WAD (10^18) precision.",

--- a/usdd-skill/resources/usdd_contracts.json
+++ b/usdd-skill/resources/usdd_contracts.json
@@ -332,7 +332,7 @@
   },
   "notes": {
     "psm": "UsddPsm allows 1:1 swaps between USDD and USDT. buyGem(usr, gemAmt) = spend USDD, receive USDT. sellGem(usr, gemAmt) = spend USDT, receive USDD. gemAmt is in USDT decimals (6). Fees (tin/tout) are currently 0.",
-    "psm_approval": "For sellGem: approve PSM GemJoin (psmGemJoin) to spend USDT. For buyGem: approve UsddJoin (usddJoin) to spend USDD.",
+    "psm_approval": "For sellGem: approve PSM GemJoin (psmGemJoin) to spend USDT. For buyGem: approve PSM (psm) to spend USDD.",
     "vaults": "MakerDAO-style CDP system. GemJoin adapters handle join/exit of collateral. DssCdpManager manages CDP lifecycle. Vat is the core accounting engine.",
     "ilk_encoding": "Vault type names (TRX-A, TRX-B, etc.) are encoded as bytes32 using ethers-style left-padded UTF-8.",
     "decimals": "USDD uses 18 decimals. USDT/USDC use 6 decimals. TRX uses 6 decimals. JST uses 18 decimals. Vat uses RAY (10^27) and WAD (10^18) precision.",

--- a/usdd-skill/scripts/balance.js
+++ b/usdd-skill/scripts/balance.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+/**
+ * balance.js — Check USDD, USDT, USDC, JST, and TRX balances.
+ *
+ * Usage:
+ *   node balance.js [--address <wallet>]
+ *
+ * Examples:
+ *   node balance.js
+ *   node balance.js --address TXYzL2gqz5AB4dbGeiX9h8unkKHxuWwb
+ */
+
+const { CONTRACTS, getTronWeb, getTronWebReadOnly, getNetwork, fromSun, outputJSON, log } = require("./utils");
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  // Parse --address flag
+  let address = null;
+  const addrIdx = args.indexOf("--address");
+  if (addrIdx !== -1 && addrIdx + 1 < args.length) {
+    address = args[addrIdx + 1];
+  }
+
+  let tronWeb;
+  if (address) {
+    tronWeb = getTronWebReadOnly();
+  } else {
+    tronWeb = getTronWeb();
+    address = tronWeb.defaultAddress.base58;
+  }
+
+  const network = getNetwork();
+  const tokens = CONTRACTS.tokens[network];
+  if (!tokens) throw new Error(`No tokens configured for network "${network}".`);
+
+  log(`Checking balances for ${address} on ${network} ...`);
+
+  const balances = [];
+
+  for (const token of Object.values(tokens)) {
+    try {
+      if (token.is_native) {
+        // TRX: use native balance query
+        const rawBalance = await tronWeb.trx.getBalance(address);
+        balances.push({
+          symbol: token.symbol,
+          balance: fromSun(rawBalance, token.decimals),
+          address: null,
+        });
+      } else {
+        // TRC20: use balanceOf
+        const contract = await tronWeb.contract(
+          [CONTRACTS.abi.trc20.balanceOf],
+          token.address
+        );
+        const rawBalance = await contract.balanceOf(address).call();
+        balances.push({
+          symbol: token.symbol,
+          balance: fromSun(BigInt(rawBalance), token.decimals),
+          address: token.address,
+        });
+      }
+    } catch (e) {
+      balances.push({
+        symbol: token.symbol,
+        balance: "0",
+        address: token.address || null,
+        error: e.message,
+      });
+    }
+    // Avoid rate-limiting on TronGrid free tier
+    await new Promise((r) => setTimeout(r, 300));
+  }
+
+  outputJSON({ wallet: address, network, balances });
+}
+
+main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });

--- a/usdd-skill/scripts/psm-info.js
+++ b/usdd-skill/scripts/psm-info.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+/**
+ * psm-info.js — Read PSM state: fees, USDT reserves, and USDD total supply.
+ *
+ * No private key required.
+ *
+ * Usage:
+ *   node psm-info.js
+ */
+
+const { CONTRACTS, getTronWebReadOnly, getNetwork, getContracts, resolveToken, fromSun, outputJSON, log } = require("./utils");
+
+async function main() {
+  const tronWeb = getTronWebReadOnly();
+  const network = getNetwork();
+  const contracts = getContracts();
+
+  log(`Querying PSM state on ${network} ...`);
+
+  const psmAddress = contracts.psm.address;
+  const gemJoinAddress = contracts.psmGemJoin.address;
+
+  // Query PSM fees (tin = buy fee, tout = sell fee)
+  const psmContract = await tronWeb.contract(
+    [CONTRACTS.abi.psm.tin, CONTRACTS.abi.psm.tout],
+    psmAddress
+  );
+
+  const [tinRaw, toutRaw] = await Promise.all([
+    psmContract.tin().call(),
+    psmContract.tout().call(),
+  ]);
+
+  // tin/tout are WAD values (10^18 = 100%). 0 = zero fee.
+  const tin = fromSun(BigInt(tinRaw), 18);
+  const tout = fromSun(BigInt(toutRaw), 18);
+
+  // Query USDT balance held by PSM GemJoin (available reserves)
+  const usdt = resolveToken("USDT");
+  const usdtContract = await tronWeb.contract(
+    [CONTRACTS.abi.trc20.balanceOf],
+    usdt.address
+  );
+  const usdtReserveRaw = await usdtContract.balanceOf(gemJoinAddress).call();
+  const usdtReserve = fromSun(BigInt(usdtReserveRaw), usdt.decimals);
+
+  // Query USDD total supply
+  const usdd = resolveToken("USDD");
+  const usddContract = await tronWeb.contract(
+    [CONTRACTS.abi.trc20.totalSupply],
+    usdd.address
+  );
+  const usddSupplyRaw = await usddContract.totalSupply().call();
+  const usddTotalSupply = fromSun(BigInt(usddSupplyRaw), usdd.decimals);
+
+  outputJSON({
+    network,
+    psm: {
+      address: psmAddress,
+      gem_join: gemJoinAddress,
+    },
+    fees: {
+      tin,
+      tout,
+      tin_pct: (parseFloat(tin) * 100).toFixed(4) + "%",
+      tout_pct: (parseFloat(tout) * 100).toFixed(4) + "%",
+    },
+    reserves: {
+      usdt_available: usdtReserve,
+    },
+    usdd: {
+      total_supply: usddTotalSupply,
+    },
+  });
+}
+
+main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });

--- a/usdd-skill/scripts/psm-swap.js
+++ b/usdd-skill/scripts/psm-swap.js
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+/**
+ * psm-swap.js — Buy or sell USDT via the USDD Peg Stability Module.
+ *
+ * sell: Deposit USDT to PSM, receive USDD 1:1 (zero fee).
+ * buy:  Deposit USDD to PSM, receive USDT 1:1 (zero fee).
+ *
+ * The amount is always in USDT terms (e.g., "1000" = 1000 USDT).
+ * The script auto-handles TRC20 approval.
+ *
+ * Usage:
+ *   node psm-swap.js <buy|sell> <amount> [--dry-run]
+ *
+ * Examples:
+ *   node psm-swap.js sell 1000 --dry-run     # Preview: sell 1000 USDT -> receive 1000 USDD
+ *   node psm-swap.js sell 500                 # Execute: sell 500 USDT for USDD
+ *   node psm-swap.js buy 1000 --dry-run      # Preview: spend USDD -> receive 1000 USDT
+ *   node psm-swap.js buy 250                  # Execute: buy 250 USDT with USDD
+ */
+
+const { CONTRACTS, getTronWeb, getNetwork, getContracts, resolveToken, toSun, fromSun, outputJSON, log } = require("./utils");
+
+const MAX_UINT256 = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error("Usage: node psm-swap.js <buy|sell> <amount> [--dry-run]");
+    process.exit(1);
+  }
+
+  const direction = args[0].toLowerCase();
+  if (direction !== "buy" && direction !== "sell") {
+    console.error(`Invalid direction "${args[0]}". Use "buy" or "sell".`);
+    process.exit(1);
+  }
+
+  const amountHuman = args[1];
+  const dryRun = args.includes("--dry-run");
+
+  const tronWeb = getTronWeb();
+  const network = getNetwork();
+  const contracts = getContracts();
+  const walletAddress = tronWeb.defaultAddress.base58;
+
+  const psmAddress = contracts.psm.address;
+  const gemJoinAddress = contracts.psmGemJoin.address;
+  const usdtToken = resolveToken("USDT");
+  const usddToken = resolveToken("USDD");
+
+  // gemAmt is always in USDT decimals (6)
+  const gemAmtRaw = toSun(amountHuman, usdtToken.decimals);
+
+  const result = {
+    action: `psm_${direction}`,
+    direction,
+    amount_usdt: amountHuman,
+    psm_address: psmAddress,
+    wallet: walletAddress,
+    dry_run: dryRun,
+  };
+
+  if (direction === "sell") {
+    // sell USDT -> receive USDD
+    result.input_token = "USDT";
+    result.output_token = "USDD";
+    log(`PSM sell: ${amountHuman} USDT -> USDD ...`);
+
+    // Check USDT balance
+    log("Checking USDT balance ...");
+    const usdtContract = await tronWeb.contract(
+      [CONTRACTS.abi.trc20.balanceOf],
+      usdtToken.address
+    );
+    const usdtBalance = BigInt(await usdtContract.balanceOf(walletAddress).call());
+    result.usdt_balance = fromSun(usdtBalance, usdtToken.decimals);
+
+    if (usdtBalance < gemAmtRaw) {
+      result.status = "failed";
+      result.error = `Insufficient USDT balance. Have: ${result.usdt_balance}, Need: ${amountHuman}`;
+      outputJSON(result);
+      return;
+    }
+
+    // Check USDT approval to PSM GemJoin
+    log("Checking USDT allowance for PSM GemJoin ...");
+    const approvalContract = await tronWeb.contract(
+      [CONTRACTS.abi.trc20.allowance, CONTRACTS.abi.trc20.approve],
+      usdtToken.address
+    );
+    const allowance = BigInt(await approvalContract.allowance(walletAddress, gemJoinAddress).call());
+    result.current_allowance = fromSun(allowance, usdtToken.decimals);
+    result.needs_approval = allowance < gemAmtRaw;
+
+    if (dryRun) {
+      result.status = "dry_run";
+      log("Dry run complete.");
+      outputJSON(result);
+      return;
+    }
+
+    // Approve if needed
+    if (allowance < gemAmtRaw) {
+      log("Approving PSM GemJoin to spend USDT ...");
+      const approveTx = await approvalContract.approve(gemJoinAddress, MAX_UINT256).send({
+        feeLimit: 50_000_000,
+        shouldPollResponse: false,
+      });
+      result.approve_tx = approveTx;
+      log(`Approval tx: ${approveTx}`);
+      await new Promise((r) => setTimeout(r, 4000));
+    }
+
+    // Execute sellGem
+    log("Executing PSM sellGem ...");
+    const psmContract = await tronWeb.contract(
+      [CONTRACTS.abi.psm.sellGem],
+      psmAddress
+    );
+    const tx = await psmContract.sellGem(walletAddress, String(gemAmtRaw)).send({
+      feeLimit: 150_000_000,
+      shouldPollResponse: false,
+    });
+    result.status = "submitted";
+    result.tx_id = tx;
+    result.expected_usdd = amountHuman;
+    log(`Transaction: ${tx}`);
+
+  } else {
+    // buy USDT <- spend USDD
+    result.input_token = "USDD";
+    result.output_token = "USDT";
+    log(`PSM buy: spend USDD -> ${amountHuman} USDT ...`);
+
+    // Calculate USDD needed (1:1 but different decimals: USDD=18, USDT=6)
+    const usddNeeded = toSun(amountHuman, usddToken.decimals);
+
+    // Check USDD balance
+    log("Checking USDD balance ...");
+    const usddContract = await tronWeb.contract(
+      [CONTRACTS.abi.trc20.balanceOf],
+      usddToken.address
+    );
+    const usddBalance = BigInt(await usddContract.balanceOf(walletAddress).call());
+    result.usdd_balance = fromSun(usddBalance, usddToken.decimals);
+
+    if (usddBalance < usddNeeded) {
+      result.status = "failed";
+      result.error = `Insufficient USDD balance. Have: ${result.usdd_balance}, Need: ${amountHuman}`;
+      outputJSON(result);
+      return;
+    }
+
+    // buyGem does dai.transferFrom(msg.sender, address(this), ...) directly,
+    // so approval must target the PSM contract itself.
+    log("Checking USDD allowance for PSM ...");
+    const approvalContract = await tronWeb.contract(
+      [CONTRACTS.abi.trc20.allowance, CONTRACTS.abi.trc20.approve],
+      usddToken.address
+    );
+    const allowance = BigInt(await approvalContract.allowance(walletAddress, psmAddress).call());
+    result.current_allowance = fromSun(allowance, usddToken.decimals);
+    result.needs_approval = allowance < usddNeeded;
+
+    if (dryRun) {
+      result.status = "dry_run";
+      log("Dry run complete.");
+      outputJSON(result);
+      return;
+    }
+
+    // Approve if needed
+    if (allowance < usddNeeded) {
+      log("Approving PSM to spend USDD ...");
+      const approveTx = await approvalContract.approve(psmAddress, MAX_UINT256).send({
+        feeLimit: 50_000_000,
+        shouldPollResponse: false,
+      });
+      result.approve_tx = approveTx;
+      log(`Approval tx: ${approveTx}`);
+      await new Promise((r) => setTimeout(r, 4000));
+    }
+
+    // Execute buyGem
+    log("Executing PSM buyGem ...");
+    const psmContract = await tronWeb.contract(
+      [CONTRACTS.abi.psm.buyGem],
+      psmAddress
+    );
+    const tx = await psmContract.buyGem(walletAddress, String(gemAmtRaw)).send({
+      feeLimit: 150_000_000,
+      shouldPollResponse: false,
+    });
+    result.status = "submitted";
+    result.tx_id = tx;
+    result.expected_usdt = amountHuman;
+    log(`Transaction: ${tx}`);
+  }
+
+  outputJSON(result);
+}
+
+main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });

--- a/usdd-skill/scripts/psm-swap.js
+++ b/usdd-skill/scripts/psm-swap.js
@@ -23,6 +23,23 @@ const { CONTRACTS, getTronWeb, getNetwork, getContracts, resolveToken, toSun, fr
 
 const MAX_UINT256 = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
 
+/**
+ * Wait until on-chain allowance meets the required amount.
+ * Retries every `intervalMs` up to `maxRetries` times.
+ */
+async function waitForAllowance(approvalContract, owner, spender, requiredAmt, { decimals, intervalMs = 4000, maxRetries = 10 } = {}) {
+  for (let i = 0; i < maxRetries; i++) {
+    const current = BigInt(await approvalContract.allowance(owner, spender).call());
+    if (current >= requiredAmt) {
+      log(`Allowance confirmed: ${fromSun(current, decimals)}`);
+      return;
+    }
+    log(`Waiting for allowance confirmation (attempt ${i + 1}/${maxRetries}) ...`);
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`Allowance not confirmed after ${maxRetries} retries`);
+}
+
 async function main() {
   const args = process.argv.slice(2);
   if (args.length < 2) {
@@ -110,7 +127,7 @@ async function main() {
       });
       result.approve_tx = approveTx;
       log(`Approval tx: ${approveTx}`);
-      await new Promise((r) => setTimeout(r, 4000));
+      await waitForAllowance(approvalContract, walletAddress, gemJoinAddress, gemAmtRaw, { decimals: usdtToken.decimals });
     }
 
     // Execute sellGem
@@ -153,14 +170,13 @@ async function main() {
       return;
     }
 
-    // buyGem calls usddJoin.join internally, which does transferFrom on USDD.
-    // Approval must target usddJoin, not the PSM contract.
-    log("Checking USDD allowance for UsddJoin ...");
+    // buyGem requires USDD approval for the PSM contract (which calls transferFrom).
+    log("Checking USDD allowance for PSM ...");
     const approvalContract = await tronWeb.contract(
       [CONTRACTS.abi.trc20.allowance, CONTRACTS.abi.trc20.approve],
       usddToken.address
     );
-    const allowance = BigInt(await approvalContract.allowance(walletAddress, usddJoinAddress).call());
+    const allowance = BigInt(await approvalContract.allowance(walletAddress, psmAddress).call());
     result.current_allowance = fromSun(allowance, usddToken.decimals);
     result.needs_approval = allowance < usddNeeded;
 
@@ -173,14 +189,14 @@ async function main() {
 
     // Approve if needed
     if (allowance < usddNeeded) {
-      log("Approving UsddJoin to spend USDD ...");
-      const approveTx = await approvalContract.approve(usddJoinAddress, MAX_UINT256).send({
+      log("Approving PSM to spend USDD ...");
+      const approveTx = await approvalContract.approve(psmAddress, MAX_UINT256).send({
         feeLimit: 50_000_000,
         shouldPollResponse: false,
       });
       result.approve_tx = approveTx;
       log(`Approval tx: ${approveTx}`);
-      await new Promise((r) => setTimeout(r, 4000));
+      await waitForAllowance(approvalContract, walletAddress, psmAddress, usddNeeded, { decimals: usddToken.decimals });
     }
 
     // Execute buyGem

--- a/usdd-skill/scripts/psm-swap.js
+++ b/usdd-skill/scripts/psm-swap.js
@@ -46,6 +46,7 @@ async function main() {
 
   const psmAddress = contracts.psm.address;
   const gemJoinAddress = contracts.psmGemJoin.address;
+  const usddJoinAddress = contracts.usddJoin.address;
   const usdtToken = resolveToken("USDT");
   const usddToken = resolveToken("USDD");
 
@@ -152,14 +153,14 @@ async function main() {
       return;
     }
 
-    // buyGem does dai.transferFrom(msg.sender, address(this), ...) directly,
-    // so approval must target the PSM contract itself.
-    log("Checking USDD allowance for PSM ...");
+    // buyGem calls usddJoin.join internally, which does transferFrom on USDD.
+    // Approval must target usddJoin, not the PSM contract.
+    log("Checking USDD allowance for UsddJoin ...");
     const approvalContract = await tronWeb.contract(
       [CONTRACTS.abi.trc20.allowance, CONTRACTS.abi.trc20.approve],
       usddToken.address
     );
-    const allowance = BigInt(await approvalContract.allowance(walletAddress, psmAddress).call());
+    const allowance = BigInt(await approvalContract.allowance(walletAddress, usddJoinAddress).call());
     result.current_allowance = fromSun(allowance, usddToken.decimals);
     result.needs_approval = allowance < usddNeeded;
 
@@ -172,8 +173,8 @@ async function main() {
 
     // Approve if needed
     if (allowance < usddNeeded) {
-      log("Approving PSM to spend USDD ...");
-      const approveTx = await approvalContract.approve(psmAddress, MAX_UINT256).send({
+      log("Approving UsddJoin to spend USDD ...");
+      const approveTx = await approvalContract.approve(usddJoinAddress, MAX_UINT256).send({
         feeLimit: 50_000_000,
         shouldPollResponse: false,
       });

--- a/usdd-skill/scripts/utils.js
+++ b/usdd-skill/scripts/utils.js
@@ -1,0 +1,141 @@
+/**
+ * Shared utilities for USDD / JUST Protocol skill scripts.
+ */
+
+const { TronWeb } = require("tronweb");
+const path = require("path");
+const fs = require("fs");
+
+const CONTRACTS = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "resources", "usdd_contracts.json"), "utf-8")
+);
+
+function getNetwork() {
+  return (process.env.TRON_NETWORK || "mainnet").toLowerCase();
+}
+
+function getTronWeb() {
+  const network = getNetwork();
+  const hosts = { mainnet: "https://api.trongrid.io", nile: "https://nile.trongrid.io", shasta: "https://api.shasta.trongrid.io" };
+  const fullHost = hosts[network];
+  if (!fullHost) throw new Error(`Unknown network "${network}".`);
+  const privateKey = process.env.TRON_PRIVATE_KEY;
+  if (!privateKey) throw new Error("TRON_PRIVATE_KEY environment variable is required");
+  const opts = { fullHost, privateKey };
+  if (process.env.TRONGRID_API_KEY) opts.headers = { "TRON-PRO-API-KEY": process.env.TRONGRID_API_KEY };
+  return new TronWeb(opts);
+}
+
+function getTronWebReadOnly() {
+  const network = getNetwork();
+  const hosts = { mainnet: "https://api.trongrid.io", nile: "https://nile.trongrid.io", shasta: "https://api.shasta.trongrid.io" };
+  const fullHost = hosts[network];
+  if (!fullHost) throw new Error(`Unknown network "${network}".`);
+  const opts = { fullHost };
+  if (process.env.TRONGRID_API_KEY) opts.headers = { "TRON-PRO-API-KEY": process.env.TRONGRID_API_KEY };
+  const tw = new TronWeb(opts);
+  // Set a zero-value default address so read-only contract calls have an owner_address
+  tw.defaultAddress = {
+    hex: "410000000000000000000000000000000000000000",
+    base58: "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb",
+  };
+  return tw;
+}
+
+/**
+ * Resolve a token by symbol or address from CONTRACTS.tokens.
+ * @param {string} symbolOrAddress - Token symbol (e.g. "USDD") or TRON address.
+ * @returns {{ address: string|null, symbol: string, decimals: number, is_native?: boolean }}
+ */
+function resolveToken(symbolOrAddress) {
+  const network = getNetwork();
+  const tokens = CONTRACTS.tokens[network];
+  if (!tokens) throw new Error(`No tokens configured for network "${network}".`);
+
+  const bySymbol = Object.values(tokens).find(
+    (t) => t.symbol.toLowerCase() === symbolOrAddress.toLowerCase()
+  );
+  if (bySymbol) return bySymbol;
+
+  const byAddress = Object.values(tokens).find(
+    (t) => t.address === symbolOrAddress
+  );
+  if (byAddress) return byAddress;
+
+  throw new Error(
+    `Unknown token "${symbolOrAddress}". Available: ${Object.values(tokens).map((t) => t.symbol).join(", ")}`
+  );
+}
+
+/**
+ * Resolve a vault by name from CONTRACTS.vaults.
+ * @param {string} vaultName - Vault name (e.g. "TRX-A").
+ * @returns {{ name: string, gemJoin: string, collateral: string, collateral_decimals: number, stability_fee_pct: number, is_native: boolean }}
+ */
+function resolveVault(vaultName) {
+  const network = getNetwork();
+  const vaults = CONTRACTS.vaults[network];
+  if (!vaults) throw new Error(`No vaults configured for network "${network}".`);
+  const match = vaults.find((v) => v.name.toLowerCase() === vaultName.toLowerCase());
+  if (!match) throw new Error(`Unknown vault "${vaultName}". Available: ${vaults.map((v) => v.name).join(", ")}`);
+  return match;
+}
+
+/**
+ * Get all vault configs for the current network.
+ */
+function getVaults() {
+  const network = getNetwork();
+  return CONTRACTS.vaults[network] || [];
+}
+
+/**
+ * Get contract addresses for the current network.
+ */
+function getContracts() {
+  const network = getNetwork();
+  const contracts = CONTRACTS.contracts[network];
+  if (!contracts) throw new Error(`No contracts configured for network "${network}".`);
+  return contracts;
+}
+
+/**
+ * Encode a vault name (e.g. "TRX-A") as a bytes32 hex string.
+ */
+function ilkToBytes32(ilkName) {
+  const hex = Buffer.from(ilkName, "utf-8").toString("hex");
+  return "0x" + hex.padEnd(64, "0");
+}
+
+function toSun(amount, decimals) {
+  const parts = String(amount).split(".");
+  const whole = parts[0] || "0";
+  const frac = (parts[1] || "").slice(0, decimals).padEnd(decimals, "0");
+  return BigInt(whole) * BigInt(10 ** decimals) + BigInt(frac);
+}
+
+function fromSun(raw, decimals) {
+  const str = String(raw).padStart(decimals + 1, "0");
+  const whole = str.slice(0, str.length - decimals) || "0";
+  const frac = str.slice(str.length - decimals).replace(/0+$/, "");
+  return frac ? `${whole}.${frac}` : whole;
+}
+
+function outputJSON(data) { process.stdout.write(JSON.stringify(data, null, 2) + "\n"); }
+function log(msg) { process.stderr.write(msg + "\n"); }
+
+module.exports = {
+  CONTRACTS,
+  getTronWeb,
+  getTronWebReadOnly,
+  getNetwork,
+  resolveToken,
+  resolveVault,
+  getVaults,
+  getContracts,
+  ilkToBytes32,
+  toSun,
+  fromSun,
+  outputJSON,
+  log,
+};

--- a/usdd-skill/scripts/vault-info.js
+++ b/usdd-skill/scripts/vault-info.js
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+/**
+ * vault-info.js — Read vault (CDP) positions and protocol parameters.
+ *
+ * No private key required. Queries the Vat and DssCdpManager for vault data.
+ *
+ * Usage:
+ *   node vault-info.js [--vault TRX-A] [--cdp <cdpId>]
+ *
+ * Modes:
+ *   (no args)           Show global parameters for all vault types
+ *   --vault TRX-A       Show parameters for a specific vault type
+ *   --cdp 123           Show position for a specific CDP ID
+ *
+ * Examples:
+ *   node vault-info.js
+ *   node vault-info.js --vault TRX-A
+ *   node vault-info.js --cdp 42
+ */
+
+const { CONTRACTS, getTronWebReadOnly, getNetwork, getContracts, getVaults, resolveVault, ilkToBytes32, fromSun, outputJSON, log } = require("./utils");
+
+const RAY = BigInt(10) ** 27n;
+const WAD = BigInt(10) ** 18n;
+
+async function main() {
+  const args = process.argv.slice(2);
+  const tronWeb = getTronWebReadOnly();
+  const network = getNetwork();
+  const contracts = getContracts();
+
+  // Parse flags
+  let vaultFilter = null;
+  let cdpId = null;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--vault" && i + 1 < args.length) vaultFilter = args[++i];
+    if (args[i] === "--cdp" && i + 1 < args.length) cdpId = parseInt(args[++i], 10);
+  }
+
+  // If a specific CDP ID is provided, query its position
+  if (cdpId !== null) {
+    log(`Querying CDP #${cdpId} ...`);
+    await queryCdp(tronWeb, contracts, cdpId);
+    return;
+  }
+
+  // Otherwise, show vault type parameters
+  const vaults = vaultFilter ? [resolveVault(vaultFilter)] : getVaults();
+  log(`Querying vault parameters on ${network} ...`);
+
+  const vatContract = await tronWeb.contract(
+    [CONTRACTS.abi.vat.ilks],
+    contracts.vat.address
+  );
+
+  const results = [];
+  for (const vault of vaults) {
+    try {
+      const ilk = ilkToBytes32(vault.name);
+      const ilkData = await vatContract.ilks(ilk).call();
+
+      // ilkData: [Art, rate, spot, line, dust]
+      const Art = BigInt(ilkData[0] || ilkData.Art || 0);
+      const rate = BigInt(ilkData[1] || ilkData.rate || 0);
+      const spot = BigInt(ilkData[2] || ilkData.spot || 0);
+      const line = BigInt(ilkData[3] || ilkData.line || 0);
+      const dust = BigInt(ilkData[4] || ilkData.dust || 0);
+
+      // Total debt for this vault type = Art * rate / RAY (in WAD = 18 decimals)
+      const totalDebt = rate > 0n ? (Art * rate) / RAY : 0n;
+
+      results.push({
+        name: vault.name,
+        collateral: vault.collateral,
+        gem_join: vault.gemJoin,
+        stability_fee_pct: vault.stability_fee_pct,
+        total_normalized_debt: fromSun(Art, 18),
+        total_debt_usdd: fromSun(totalDebt, 18),
+        rate: fromSun(rate, 27),
+        spot: fromSun(spot, 27),
+        debt_ceiling_usdd: fromSun(line / RAY, 18),
+        dust_usdd: fromSun(dust / RAY, 18),
+      });
+    } catch (e) {
+      results.push({
+        name: vault.name,
+        error: e.message,
+      });
+    }
+  }
+
+  outputJSON({ network, vaults: results });
+}
+
+async function queryCdp(tronWeb, contracts, cdpId) {
+  const cdpManagerContract = await tronWeb.contract(
+    [CONTRACTS.abi.cdpManager.urns, CONTRACTS.abi.cdpManager.ilks, CONTRACTS.abi.cdpManager.owns],
+    contracts.cdpManager.address
+  );
+
+  // Get CDP info from manager
+  const [urn, ilkBytes, owner] = await Promise.all([
+    cdpManagerContract.urns(cdpId).call(),
+    cdpManagerContract.ilks(cdpId).call(),
+    cdpManagerContract.owns(cdpId).call(),
+  ]);
+
+  const urnAddress = tronWeb.address.fromHex(urn);
+  const ownerAddress = tronWeb.address.fromHex(owner);
+
+  // Decode ilk name from bytes32
+  const ilkHex = typeof ilkBytes === "string" ? ilkBytes : ilkBytes.toString(16);
+  const ilkClean = ilkHex.replace(/^0x/, "").replace(/0+$/, "");
+  const ilkName = Buffer.from(ilkClean, "hex").toString("utf-8");
+
+  // Query Vat for urn position
+  const vatContract = await tronWeb.contract(
+    [CONTRACTS.abi.vat.urns, CONTRACTS.abi.vat.ilks],
+    contracts.vat.address
+  );
+
+  const [urnData, ilkData] = await Promise.all([
+    vatContract.urns(ilkBytes, urn).call(),
+    vatContract.ilks(ilkBytes).call(),
+  ]);
+
+  const ink = BigInt(urnData[0] || urnData.ink || 0); // collateral (WAD)
+  const art = BigInt(urnData[1] || urnData.art || 0); // normalized debt (WAD)
+  const rate = BigInt(ilkData[1] || ilkData.rate || 0);
+  const spot = BigInt(ilkData[2] || ilkData.spot || 0);
+
+  // Actual debt = art * rate / RAY
+  const actualDebt = rate > 0n ? (art * rate) / RAY : 0n;
+
+  // Max borrowable = ink * spot (in RAD = 10^45)
+  // Collat ratio = (ink * spot) / (art * rate) if art > 0
+  let collatRatio = "N/A";
+  if (art > 0n && rate > 0n) {
+    const collatValue = ink * spot; // RAD
+    const debtValue = art * rate;   // RAD
+    const ratioBps = (collatValue * 10000n) / debtValue;
+    collatRatio = (Number(ratioBps) / 100).toFixed(2) + "%";
+  }
+
+  outputJSON({
+    cdp_id: cdpId,
+    owner: ownerAddress,
+    urn: urnAddress,
+    ilk: ilkName,
+    collateral_locked: fromSun(ink, 18),
+    normalized_debt: fromSun(art, 18),
+    actual_debt_usdd: fromSun(actualDebt, 18),
+    rate: fromSun(rate, 27),
+    collateralization_ratio: collatRatio,
+  });
+}
+
+main().catch((e) => { outputJSON({ error: e.message }); process.exit(1); });


### PR DESCRIPTION
## Summary
- Adds `usdd-skill` for USDD stablecoin operations via the JUST Protocol on TRON
- Swap USDT for USDD at 1:1 through the Peg Stability Module (PSM)
- Query vault (CDP) positions and protocol parameters
- Check token balances (USDD, USDT, USDC, TRX, JST)

## Scripts
- `psm-swap.js` — Buy/sell USDT via PSM at 1:1 (zero fee)
- `psm-info.js` — PSM state: fees, USDT reserves, USDD supply
- `balance.js` — Check token balances
- `vault-info.js` — Vault (CDP) parameters and position queries

Source: https://github.com/M2M-TRC8004-Registry/usdd-skill