### PR TITLE
chore: upgrade @bankofai/x402 to 0.4.2

### DIFF
--- a/x402-payment/package.json
+++ b/x402-payment/package.json
@@ -11,7 +11,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@bankofai/x402": "0.4.1",
+    "@bankofai/x402": "0.4.2",
     "tronweb": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Upgrade `@bankofai/x402` dependency from `0.4.1` to `0.4.2` in x402-payment skill

## Test plan
- [x] Verify x402-payment skill starts correctly with `npm start`
- [x] Test x402 payment invocation against testnet