### PR TITLE
Fix GasFree typed-data address conversion

### DIFF
--- a/x402-payment/SKILL.md
+++ b/x402-payment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x402-payment
 description: "Pay for x402-enabled Agent endpoints using ERC20 tokens (USDT/USDC) on EVM or TRC20 tokens (USDT/USDD) on TRON."
-version: 1.4.0
+version: 1.5.1
 author: bankofai
 homepage: https://bankofai.io
 tags: [crypto, payments, x402, agents, api, usdt, usdd, usdc, tron, ethereum, evm, erc20, trc20]

--- a/x402-payment/package.json
+++ b/x402-payment/package.json
@@ -11,7 +11,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@bankofai/x402": "0.5.1-beta.0",
+    "@bankofai/x402": "0.5.1",
     "tronweb": "^6.0.0"
   }
 }

--- a/x402-payment/package.json
+++ b/x402-payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-payment-skill",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "x402 payment skill for TRON and EVM",
   "type": "module",
   "scripts": {

--- a/x402-payment/package.json
+++ b/x402-payment/package.json
@@ -11,7 +11,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@bankofai/x402": "0.5.0",
+    "@bankofai/x402": "0.5.1-beta.0",
     "tronweb": "^6.0.0"
   }
 }

--- a/x402-payment/src/gasfree_withdraw_all.ts
+++ b/x402-payment/src/gasfree_withdraw_all.ts
@@ -55,7 +55,6 @@ async function main() {
 
   const network = options.network || 'nile';
   const tokenAddress = options.token || 'TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf';
-  const toAddress = options.to || 'TXCxox5kcZiZNq4Ysv86m8icv4JfxXWkfe';
 
   const baseUrl = GASFREE_API_BASE_URLS[`tron:${network}`];
   if (!baseUrl) {
@@ -70,6 +69,7 @@ async function main() {
 
   const signer = await TronClientSigner.create();
   const userAddress = signer.getAddress();
+  const toAddress = options.to || userAddress;
   const gasFreeClient = new GasFreeAPIClient(baseUrl);
 
   console.error(`[gasfree-withdraw] Network: ${network}, User: ${userAddress}`);

--- a/x402-payment/src/gasfree_withdraw_all.ts
+++ b/x402-payment/src/gasfree_withdraw_all.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+import { TronWeb } from 'tronweb';
+import { GasFreeAPIClient, GASFREE_API_BASE_URLS, getChainId, TronClientSigner } from '@bankofai/x402';
+
+const TRONWEB_READONLY_DUMMY_KEY = '0000000000000000000000000000000000000000000000000000000000000001';
+const TRON_RPC_URLS: Record<string, string> = {
+  mainnet: 'https://api.trongrid.io',
+  nile: 'https://nile.trongrid.io',
+  shasta: 'https://api.shasta.trongrid.io',
+};
+
+function isTronAddress(address: string): boolean {
+  return /^T[1-9A-HJ-NP-Za-km-z]{33}$/.test(address);
+}
+
+function tronAddressToEvmHex(tronWeb: any, address: string): string {
+  if (!isTronAddress(address)) return address;
+  const hex41 = String(tronWeb.address.toHex(address));
+  return `0x${hex41.replace(/^41/i, '')}`;
+}
+
+function convertTronAddressesDeep(tronWeb: any, value: unknown): unknown {
+  if (typeof value === 'string') {
+    return isTronAddress(value) ? tronAddressToEvmHex(tronWeb, value) : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => convertTronAddressesDeep(tronWeb, v));
+  }
+  if (value && typeof value === 'object') {
+    const next: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      next[key] = convertTronAddressesDeep(tronWeb, val);
+    }
+    return next;
+  }
+  return value;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const options: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const value = args[i + 1];
+      if (value && !value.startsWith('--')) {
+        options[key] = value;
+        i++;
+      } else {
+        options[key] = 'true';
+      }
+    }
+  }
+
+  const network = options.network || 'nile';
+  const tokenAddress = options.token || 'TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf';
+  const toAddress = options.to || 'TXCxox5kcZiZNq4Ysv86m8icv4JfxXWkfe';
+
+  const baseUrl = GASFREE_API_BASE_URLS[`tron:${network}`];
+  if (!baseUrl) {
+    console.error(`Error: GasFree not supported on "${network}". Supported: mainnet, nile, shasta`);
+    process.exit(1);
+  }
+
+  const tronWeb = new TronWeb({
+    fullHost: TRON_RPC_URLS[network],
+    privateKey: TRONWEB_READONLY_DUMMY_KEY,
+  });
+
+  const signer = await TronClientSigner.create();
+  const userAddress = signer.getAddress();
+  const gasFreeClient = new GasFreeAPIClient(baseUrl);
+
+  console.error(`[gasfree-withdraw] Network: ${network}, User: ${userAddress}`);
+  const info = await gasFreeClient.getAddressInfo(userAddress);
+  const gasfreeAddress = info.gasFreeAddress;
+  if (!gasfreeAddress) {
+    console.error(`Error: GasFree address not found for ${userAddress}`);
+    process.exit(1);
+  }
+
+  console.error(`[gasfree-withdraw] GasFree address: ${gasfreeAddress}`);
+  console.error(`[gasfree-withdraw] Active: ${info.active}, AllowSubmit: ${info.allowSubmit}, Nonce: ${info.nonce}`);
+  if (!info.active && !info.allowSubmit) {
+    console.error('[gasfree-withdraw] Error: Account not active and allowSubmit is false.');
+    process.exit(1);
+  }
+
+  const asset = info.assets.find((a: any) => a.tokenAddress === tokenAddress);
+  if (!asset) {
+    console.error(`[gasfree-withdraw] Error: Token ${tokenAddress} not found in GasFree account`);
+    process.exit(1);
+  }
+
+  const decimals = asset.decimal ?? 6;
+  const transferFee = BigInt(asset.transferFee || 0);
+  const maxFee = transferFee;
+
+  const contract = await tronWeb.contract().at(tokenAddress);
+  const gfBalance = BigInt((await contract.methods.balanceOf(gasfreeAddress).call()).toString());
+  const fmt = (v: bigint) => `${Number(v) / 10 ** decimals}`;
+
+  console.error(`[gasfree-withdraw] GasFree balance: ${fmt(gfBalance)} token`);
+  if (gfBalance <= maxFee) {
+    console.error(`[gasfree-withdraw] Error: balance ${fmt(gfBalance)} <= maxFee ${fmt(maxFee)}`);
+    process.exit(1);
+  }
+
+  const returnValue = gfBalance - maxFee;
+  const deadline = Math.floor(Date.now() / 1000) + 3600;
+
+  const providers = await gasFreeClient.getProviders();
+  if (!providers || providers.length === 0) {
+    console.error('[gasfree-withdraw] Error: No GasFree service providers available');
+    process.exit(1);
+  }
+  const provider = providers[0];
+  console.error(`[gasfree-withdraw] Provider: ${provider.address} (${provider.name})`);
+
+  const chainId = getChainId(`tron:${network}`);
+  const { TronGasFree } = await import('@gasfree/gasfree-sdk');
+  const gasFree = new TronGasFree({ chainId });
+
+  const { domain, types, message } = gasFree.assembleGasFreeTransactionJson({
+    token: tokenAddress,
+    serviceProvider: provider.address,
+    user: userAddress,
+    receiver: toAddress,
+    value: returnValue.toString(),
+    maxFee: maxFee.toString(),
+    deadline: deadline.toString(),
+    version: '1',
+    nonce: info.nonce.toString(),
+  });
+
+  const domainForSig = convertTronAddressesDeep(tronWeb, domain) as Record<string, unknown>;
+  const messageForSig = convertTronAddressesDeep(tronWeb, message) as Record<string, unknown>;
+  const signature = await signer.signTypedData(domainForSig, types, messageForSig, 'GasFreeTransaction');
+
+  console.error('[gasfree-withdraw] Submitting GasFree transaction...');
+  const traceId = await gasFreeClient.submit(domain, message, signature);
+  console.error(`[gasfree-withdraw] Trace ID: ${traceId}`);
+  console.error('[gasfree-withdraw] Waiting for completion...');
+
+  const result = await gasFreeClient.waitForSuccess(traceId, 180000, 5000);
+
+  process.stdout.write(JSON.stringify({
+    status: result.state,
+    traceId,
+    to: toAddress,
+    gasFreeAddress: gasfreeAddress,
+    token: tokenAddress,
+    amount: returnValue.toString(),
+    maxFee: maxFee.toString(),
+    txHash: result.txnHash || null,
+  }, null, 2) + '\n');
+}
+
+main().catch((err) => {
+  console.error(`[gasfree-withdraw] Error: ${err?.message || err}`);
+  process.exit(1);
+});

--- a/x402-payment/src/x402_invoke.ts
+++ b/x402-payment/src/x402_invoke.ts
@@ -35,20 +35,21 @@ function tronAddressToEvmHex(tronWeb: any, address: string): string {
   return `0x${hex41.replace(/^41/i, '')}`;
 }
 
-function convertTypedDataAddresses(
-  tronWeb: any,
-  value: Record<string, unknown>,
-  fields: Array<{ name: string; type: string }>,
-): Record<string, unknown> {
-  const next = { ...value };
-  for (const field of fields) {
-    if (field.type !== 'address') continue;
-    const current = next[field.name];
-    if (typeof current === 'string') {
-      next[field.name] = tronAddressToEvmHex(tronWeb, current);
-    }
+function convertTronAddressesDeep(tronWeb: any, value: unknown): unknown {
+  if (typeof value === 'string') {
+    return isTronAddress(value) ? tronAddressToEvmHex(tronWeb, value) : value;
   }
-  return next;
+  if (Array.isArray(value)) {
+    return value.map((v) => convertTronAddressesDeep(tronWeb, v));
+  }
+  if (value && typeof value === 'object') {
+    const next: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      next[key] = convertTronAddressesDeep(tronWeb, val);
+    }
+    return next;
+  }
+  return value;
 }
 
 function normalizeHexSignature(signature: string): string {
@@ -370,12 +371,8 @@ async function handleGasFreeActivate(
     nonce: nonce.toString(),
   });
 
-  const domainForSig = Array.isArray(types?.EIP712Domain)
-    ? convertTypedDataAddresses(tronWeb, domain, types.EIP712Domain)
-    : domain;
-  const messageForSig = Array.isArray(types?.GasFreeTransaction)
-    ? convertTypedDataAddresses(tronWeb, message, types.GasFreeTransaction)
-    : message;
+  const domainForSig = convertTronAddressesDeep(tronWeb, domain) as Record<string, unknown>;
+  const messageForSig = convertTronAddressesDeep(tronWeb, message) as Record<string, unknown>;
 
   const signature = await tronSigner.signTypedData(domainForSig, types, messageForSig, 'GasFreeTransaction');
 

--- a/x402-payment/src/x402_invoke.ts
+++ b/x402-payment/src/x402_invoke.ts
@@ -29,6 +29,28 @@ function isEvmAddress(address: string): boolean {
   return /^0x[0-9a-fA-F]{40}$/.test(address);
 }
 
+function tronAddressToEvmHex(tronWeb: any, address: string): string {
+  if (!isTronAddress(address)) return address;
+  const hex41 = String(tronWeb.address.toHex(address));
+  return `0x${hex41.replace(/^41/i, '')}`;
+}
+
+function convertTypedDataAddresses(
+  tronWeb: any,
+  value: Record<string, unknown>,
+  fields: Array<{ name: string; type: string }>,
+): Record<string, unknown> {
+  const next = { ...value };
+  for (const field of fields) {
+    if (field.type !== 'address') continue;
+    const current = next[field.name];
+    if (typeof current === 'string') {
+      next[field.name] = tronAddressToEvmHex(tronWeb, current);
+    }
+  }
+  return next;
+}
+
 function normalizeHexSignature(signature: string): string {
   return signature.replace(/^0x/i, '');
 }
@@ -348,7 +370,14 @@ async function handleGasFreeActivate(
     nonce: nonce.toString(),
   });
 
-  const signature = await tronSigner.signTypedData(domain, types, message, 'GasFreeTransaction');
+  const domainForSig = Array.isArray(types?.EIP712Domain)
+    ? convertTypedDataAddresses(tronWeb, domain, types.EIP712Domain)
+    : domain;
+  const messageForSig = Array.isArray(types?.GasFreeTransaction)
+    ? convertTypedDataAddresses(tronWeb, message, types.GasFreeTransaction)
+    : message;
+
+  const signature = await tronSigner.signTypedData(domainForSig, types, messageForSig, 'GasFreeTransaction');
 
   console.error('[gasfree-activate] Submitting GasFree transaction...');
   const traceId = await gasFreeClient.submit(domain, message, signature);

--- a/x402-payment/src/x402_invoke.ts
+++ b/x402-payment/src/x402_invoke.ts
@@ -594,10 +594,42 @@ async function main() {
   // Prefer exact_gasfree when GasFree API credentials are configured
   if (gasFreeCredentials) {
     client.registerPolicy({
-      apply(requirements: any[]) {
+      async apply(requirements: any[]) {
         const gasfree = requirements.filter((r: any) => r.scheme === 'exact_gasfree');
         const others = requirements.filter((r: any) => r.scheme !== 'exact_gasfree');
-        return [...gasfree, ...others];
+
+        if (!gasfree.length || !tronSigner) return [...gasfree, ...others];
+
+        const affordable: any[] = [];
+        for (const req of gasfree) {
+          try {
+            const networkKey = req.network;
+            const baseUrl = GASFREE_API_BASE_URLS[networkKey];
+            if (!baseUrl) continue;
+            const apiClient = new GasFreeAPIClient(baseUrl);
+            const userAddress = tronSigner.getAddress();
+            const info = await apiClient.getAddressInfo(userAddress);
+            const gasfreeAddress = info.gasFreeAddress;
+            if (!gasfreeAddress) continue;
+            const balance = await tronSigner.checkBalance(req.asset, req.network, gasfreeAddress);
+            let needed = BigInt(req.amount);
+            if (req.extra?.fee?.feeAmount) {
+              needed += BigInt(req.extra.fee.feeAmount);
+            }
+            if (balance >= needed) {
+              affordable.push(req);
+            } else {
+              console.error(
+                `[x402] exact_gasfree skipped: GasFree balance ${balance.toString()} < needed ${needed.toString()} for ${gasfreeAddress}`,
+              );
+            }
+          } catch (_) {
+            // If we can't check, keep gasfree requirement as-is.
+            affordable.push(req);
+          }
+        }
+
+        return [...affordable, ...others];
       }
     });
     console.error(`[x402] GasFree priority policy enabled.`);


### PR DESCRIPTION
## Summary
- Convert TRON Base58 addresses to EVM hex in GasFree typed-data signing
- Avoid invalid address errors from viem during GasFree activation

## Testing
- npx tsc x402-payment/src/x402_invoke.ts --gasfree-activate --network nile