### PR TITLE
chore: bump @bankofai/x402 to 0.5.4

### DIFF
--- a/x402-payment/SKILL.md
+++ b/x402-payment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x402-payment
 description: "Pay for x402-enabled Agent endpoints using ERC20 tokens (USDT/USDC) on EVM or TRC20 tokens (USDT/USDD) on TRON."
-version: 1.5.1
+version: 1.5.2
 author: bankofai
 homepage: https://bankofai.io
 tags: [crypto, payments, x402, agents, api, usdt, usdd, usdc, tron, ethereum, evm, erc20, trc20]

--- a/x402-payment/package.json
+++ b/x402-payment/package.json
@@ -11,7 +11,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@bankofai/x402": "0.5.2",
+    "@bankofai/x402": "0.5.4",
     "tronweb": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- bump @bankofai/x402 dependency to 0.5.4
- bump SKILL version to 1.5.2
