### PR TITLE
chore: bump @bankofai/x402 to 0.5.5

### DIFF
--- a/x402-payment/SKILL.md
+++ b/x402-payment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x402-payment
 description: "Pay for x402-enabled Agent endpoints using ERC20 tokens (USDT/USDC) on EVM or TRC20 tokens (USDT/USDD) on TRON."
-version: 1.5.2
+version: 1.5.4
 author: bankofai
 homepage: https://bankofai.io
 tags: [crypto, payments, x402, agents, api, usdt, usdd, usdc, tron, ethereum, evm, erc20, trc20]

--- a/x402-payment/package.json
+++ b/x402-payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-payment-skill",
-  "version": "1.5.2",
+  "version": "1.5.4",
   "description": "x402 payment skill for TRON and EVM",
   "type": "module",
   "scripts": {
@@ -11,7 +11,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@bankofai/x402": "0.5.4",
+    "@bankofai/x402": "0.5.5",
     "tronweb": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `@bankofai/x402` from 0.5.4 to 0.5.5
- Fixes null status data crash during GasFree settlement polling
- Adds `max_errors` cap for consecutive polling failures
- Guards all GasFree API responses against null data
- See [x402 v0.5.5 release notes](https://github.com/BofAI/x402/pull/57)

## Test plan
- [x] Tested GasFree payment on nile: `GET https://x402-demo.bankofai.io/protected-nile` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)