### PR TITLE
chore: bump @bankofai/x402 to 0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.5.5] - 2026-03-29
+
+### Improvements
+- **x402-payment**: Bumped `@bankofai/x402` to 0.5.6.
+
 ## [1.5.2] - 2026-03-27
 
 ### Improvements

--- a/x402-payment/SKILL.md
+++ b/x402-payment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x402-payment
 description: "Pay for x402-enabled Agent endpoints using ERC20 tokens (USDT/USDC) on EVM or TRC20 tokens (USDT/USDD) on TRON."
-version: 1.5.4
+version: 1.5.5
 author: bankofai
 homepage: https://bankofai.io
 tags: [crypto, payments, x402, agents, api, usdt, usdd, usdc, tron, ethereum, evm, erc20, trc20]
@@ -162,4 +162,3 @@ Ensure you have enough USDT/USDC/USDD in your wallet on the specified network.
 Set `X402_DEBUG=1` to include full error stack traces in the JSON output when troubleshooting failures.
 
 ---
-*Last Updated: 2026-03-11*

--- a/x402-payment/package.json
+++ b/x402-payment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-payment-skill",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "x402 payment skill for TRON and EVM",
   "type": "module",
   "scripts": {
@@ -11,7 +11,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@bankofai/x402": "0.5.5",
+    "@bankofai/x402": "0.5.6",
     "tronweb": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `@bankofai/x402` from 0.5.5 to 0.5.6
- Bump x402-payment skill version from 1.5.4 to 1.5.5
- Update CHANGELOG.md with 1.5.5 entry

## Test plan
- [x] Verify `npm install` resolves `@bankofai/x402@0.5.6` correctly
- [x] Run `npx tsx x402-payment/src/x402_invoke.ts --check` to confirm tool works

🤖 Generated with [Claude Code](https://claude.com/claude-code)