### PR TITLE
Bump sunpump-agent-skill to 1.3.0 — add token creation (sun sunpump l…

### DIFF
--- a/sunpump-agent-skill/README.md
+++ b/sunpump-agent-skill/README.md
@@ -1,6 +1,6 @@
 # SunPump Skill
 
-Trade meme tokens on **SunPump** and query token info, rankings, holders, portfolios, and trade history via `sun-cli`.
+Create and trade meme tokens on **SunPump** and query token info, rankings, holders, portfolios, and trade history via `sun-cli`.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../LICENSE)
 [![TRON](https://img.shields.io/badge/Blockchain-TRON-red)](https://tron.network/)
@@ -11,7 +11,7 @@ Trade meme tokens on **SunPump** and query token info, rankings, holders, portfo
 
 ## Approach
 
-This skill uses **sun-cli** (`@bankofai/sun-cli`) — a unified CLI for SUN.IO / SunSwap / SunPump on TRON. Trading auto-routes by token state: pre-launch (bonding curve) tokens go through `sun sunpump buy/sell`, post-launch (migrated to DEX) tokens go through `sun swap`. All SunPump data is read through the `sun sunpump *` subcommands with `--json` output for AI agent consumption.
+This skill uses **sun-cli** (`@bankofai/sun-cli`) — a unified CLI for SUN.IO / SunSwap / SunPump on TRON. Token creation goes through the SunPump agent endpoint (`sun sunpump launch` — server-side, no wallet). Trading auto-routes by token state: pre-launch (bonding curve) tokens go through `sun sunpump buy/sell`, post-launch (migrated to DEX) tokens go through `sun swap`. All SunPump data is read through the `sun sunpump *` subcommands with `--json` output for AI agent consumption.
 
 ## Files
 
@@ -31,14 +31,14 @@ npx skills add BofAI/skills
 ### 2. Install the runtime CLI
 
 ```bash
-npm install -g @bankofai/sun-cli@^1.2.0
+npm install -g @bankofai/sun-cli@^1.2.1
 ```
 
-`@bankofai/sun-cli >= 1.2.0` is required (earlier versions lack `sun sunpump buy/sell/state`). The skills CLI does **not** auto-install npm dependencies.
+`@bankofai/sun-cli >= 1.2.1` is required (earlier versions lack `sun sunpump launch`; < 1.2.0 also lack `sun sunpump buy/sell/state`). The skills CLI does **not** auto-install npm dependencies.
 
-### 3. Configure a wallet (only for write commands)
+### 3. Configure a wallet (only for trading commands)
 
-A wallet (`TRON_PRIVATE_KEY`, `TRON_MNEMONIC`, or `AGENT_WALLET_PASSWORD`) is required only for `sun swap` / `sun sunpump buy` / `sun sunpump sell`. All read endpoints work without one.
+A wallet (`TRON_PRIVATE_KEY`, `TRON_MNEMONIC`, or `AGENT_WALLET_PASSWORD`) is required only for `sun swap` / `sun sunpump buy` / `sun sunpump sell`. All read endpoints work without one, and so does token creation (`sun sunpump launch` — the platform signs server-side).
 
 
 ## Network
@@ -51,20 +51,32 @@ reachable). Drop `--network` or pass `--network mainnet`.
 
 | # | Feature | Command |
 |---|---------|---------|
-| 1 | Post-launch buy / sell | `sun --json --yes swap <tokenIn> <tokenOut> <amount>` |
-| 2 | Pre-launch buy / sell | `sun --json --yes sunpump buy <addr> --trx <n>` · `sun --json --yes sunpump sell <addr> --amount <n>` |
-| 3 | Token state (route picker) | `sun --json sunpump state <contractAddress>` |
-| 4 | User position check | `sun --json sunpump portfolio <walletAddress>` |
-| 5 | Trade history | `sun --json sunpump tx user <walletAddress> --size 20` |
-| 6 | Token info | `sun --json sunpump token get <contractAddress>` |
-| 7 | Ranking | `sun --json sunpump token ranking --type MARKET_CAP --size 10` |
-| 8 | Top holders | `sun --json sunpump token holders <contractAddress> --size 20` |
+| 1 | Create (launch) a token | `sun --json --yes sunpump launch --name <n> --symbol <s> --description <d> --image <path>` |
+| 2 | Post-launch buy / sell | `sun --json --yes swap <tokenIn> <tokenOut> <amount>` |
+| 3 | Pre-launch buy / sell | `sun --json --yes sunpump buy <addr> --trx <n>` · `sun --json --yes sunpump sell <addr> --amount <n>` |
+| 4 | Token state (route picker) | `sun --json sunpump state <contractAddress>` |
+| 5 | User position check | `sun --json sunpump portfolio <walletAddress>` |
+| 6 | Trade history | `sun --json sunpump tx user <walletAddress> --size 20` |
+| 7 | Token info | `sun --json sunpump token get <contractAddress>` |
+| 8 | Ranking | `sun --json sunpump token ranking --type MARKET_CAP --size 10` |
+| 9 | Top holders | `sun --json sunpump token holders <contractAddress> --size 20` |
 
 Ranking types: `MARKET_CAP`, `VOLUME_24H`, `PRICE_CHANGE_24H`.
 
 State values: `0 NOT_EXIST`, `1 TRADING`, `2 READY_TO_LAUNCH`, `3 LAUNCHED`.
 
 ## Usage Examples
+
+### Create a new meme token (no wallet needed — server-side creation)
+```bash
+sun --json sunpump token search MEME                       # check for symbol collisions
+sun --json --yes --dry-run sunpump launch --name "My Meme" --symbol MEME \
+  --description "The dankest meme on TRON" --image ./logo.png   # preview payload
+sun --json --yes sunpump launch --name "My Meme" --symbol MEME \
+  --description "The dankest meme on TRON" --image ./logo.png   # create (irreversible)
+sun --json sunpump state <contractAddress>                 # expect 1 (TRADING)
+```
+Always pass `--image` — launches without a logo often fail with `Invoke third part error`.
 
 ### Buy a meme token (auto-routes pre/post-launch)
 ```bash
@@ -110,6 +122,8 @@ sun --json sunpump tx user T... --size 20
 - `@bankofai/sun-cli` (installed globally)
 
 ## Version
+
+1.3.0 (2026-06-04) — adds token creation via `sun sunpump launch` (server-side `POST /ai/agentTokenLaunch`, no wallet needed); requires sun-cli ≥ 1.2.1
 
 1.2.0 (2026-05-22) — breaking: drops nile testnet (internal-only host); upstream `sun sunpump` API surface also trimmed (no more `home/kline/red-packet/campaign/referral/admin-summary/quota/tx ticker`)
 

--- a/sunpump-agent-skill/README.md
+++ b/sunpump-agent-skill/README.md
@@ -123,6 +123,8 @@ sun --json sunpump tx user T... --size 20
 
 ## Version
 
+1.3.1 (2026-06-08) — docs: clarify `sun sunpump launch` is mainnet-only (sun-cli dropped SunPump nile support again); document that `--dry-run` skips the mainnet check
+
 1.3.0 (2026-06-04) — adds token creation via `sun sunpump launch` (server-side `POST /ai/agentTokenLaunch`, no wallet needed); requires sun-cli ≥ 1.2.1
 
 1.2.0 (2026-05-22) — breaking: drops nile testnet (internal-only host); upstream `sun sunpump` API surface also trimmed (no more `home/kline/red-packet/campaign/referral/admin-summary/quota/tx ticker`)

--- a/sunpump-agent-skill/RELEASE_NOTES.md
+++ b/sunpump-agent-skill/RELEASE_NOTES.md
@@ -1,5 +1,30 @@
 # Release Notes — SunPump Meme Token Toolkit
 
+## v1.3.1 — 2026-06-08 _(docs only)_
+
+> **TL;DR** — Sync with `@bankofai/sun-cli` dropping SunPump nile support
+> again: **`sun sunpump launch` is mainnet-only**, like every other
+> `sunpump` subcommand. No skill behaviour changes — just makes the
+> launch section's network requirement explicit.
+
+### Changes
+
+- **Section 8 (Token Creation)** gains a mainnet-only warning. The
+  `sunpump` command group runs a `preAction` guard that throws
+  `SunPump is only available on mainnet (got "...")` for any non-mainnet
+  `--network`, on every subcommand including `launch`.
+- **Clarified the guard fires before the action** — so it applies even
+  under `--dry-run` (`--dry-run --network nile` errors out before
+  previewing). Drop `--network` or pass `--network mainnet`.
+- **Launch pre-validation checklist** adds a `--network` must-be-mainnet
+  step.
+
+> The rest of the skill already documented SunPump as mainnet-only (since
+> v1.2.0); this release only closes the gap in the launch-specific
+> sections.
+
+---
+
 ## v1.3.0 — 2026-06-04
 
 > **TL;DR** — Adds **token creation**: `sun sunpump launch` creates a new

--- a/sunpump-agent-skill/RELEASE_NOTES.md
+++ b/sunpump-agent-skill/RELEASE_NOTES.md
@@ -1,0 +1,236 @@
+# Release Notes — SunPump Meme Token Toolkit
+
+## v1.3.0 — 2026-06-04
+
+> **TL;DR** — Adds **token creation**: `sun sunpump launch` creates a new
+> meme token through the SunPump agent endpoint
+> (`POST /ai/agentTokenLaunch`). Creation is **server-side** — the platform
+> signs and broadcasts the creation transaction, so **no wallet is needed**.
+> Requires `@bankofai/sun-cli ≥ 1.2.1`.
+
+### Highlights
+
+- **New flow #1 — Create (launch) a token.**
+  ```bash
+  sun --json --yes sunpump launch \
+    --name "My Meme" --symbol MEME \
+    --description "The dankest meme on TRON" \
+    --image ./logo.png
+  ```
+  Required: `--name`, `--symbol`, `--description`. Optional:
+  `--image <path>` (read and sent as base64) / `--image-base64 <data>`,
+  `--twitter-url`, `--telegram-url`, `--website-url`, `--tweet-username`.
+  Returns the full token object including `contractAddress`,
+  `createTxHash`, and `logoUrl`. The new token starts on the bonding
+  curve (state `1 TRADING`) and is immediately buyable via
+  `sun sunpump buy`.
+- **Honours the standard agent flags** — `--dry-run` prints the resolved
+  payload without calling the API; `--yes` skips the interactive
+  confirmation; `--json` returns the raw token object.
+- **Pre-validation checklist extended** with a launch section: confirm
+  name/symbol/description with the user, require a logo, check for
+  symbol collisions via `sunpump token search`, dry-run first, launch
+  exactly once.
+- **Security rules extended** — token creation is irreversible; preview
+  and explicit user confirmation are mandatory, and ambiguous launch
+  errors must be checked with `sunpump token search <symbol>` before any
+  retry (the token may already exist).
+
+### Known quirks (documented in SKILL.md)
+
+| Quirk | Behavior | Workaround |
+|-------|----------|------------|
+| Launch without a logo | Opaque server error `Invoke third part error` | Always pass `--image <path>` (or `--image-base64`) |
+| `*Instant` fields in `--json` launch output | Epoch-millis ÷ 1e6 (e.g. `1780476.327`), not epoch seconds | Multiply by 1000 for epoch seconds; CLI normalizes only in human mode |
+
+### Compatibility
+
+- **Required runtime:** `@bankofai/sun-cli ≥ 1.2.1` (earlier versions
+  lack `sunpump launch`).
+- **Wallet:** unchanged for trading; `sunpump launch` itself needs **no
+  wallet** (server-side creation).
+
+### Install / upgrade
+
+```bash
+# 1. Install the skill (Claude Code / Cursor / Codex pick it up)
+npx skills add BofAI/skills
+
+# 2. Install / upgrade the runtime CLI
+npm install -g @bankofai/sun-cli@^1.2.1
+```
+
+---
+
+## v1.2.0 — 2026-05-22
+
+> **TL;DR** — SunPump is now **mainnet-only**. Any agent that hard-coded
+> `--network nile` (or any non-mainnet value) on a `sun sunpump *` command
+> must drop the flag or pass `--network mainnet`. The upstream `sun-cli`
+> SunPump API surface was also trimmed; only the trading + discovery
+> commands remain.
+
+### Highlights
+
+- **Mainnet-only enforcement.** The runtime CLI now fast-fails every
+  `sunpump` subcommand when `--network` is anything other than `mainnet`
+  with a clear error:
+  `SunPump is only available on mainnet (got "...")`.
+- **Docs in lockstep.** The README network section, `SKILL.md`
+  pre-validation checklist, AI agent flag table, trade examples, and
+  troubleshooting guide were all rewritten — no more references to nile
+  testnet, "silent fallback", or shasta.
+- **Slimmer API surface.** Endpoints that didn't fit the
+  trading + discovery loop have been removed in `@bankofai/sun-cli`.
+  Agents calling any of the removed groups (see below) need to be
+  updated.
+
+### Breaking Changes
+
+#### 1. Dropped nile testnet support
+
+**Why:** the SunPump nile API host
+(`https://tn-api.sunpump.meme/pump-api`) is internal-only and not
+publicly reachable, so any agent passing `--network nile` was previously
+hitting an unreachable host.
+
+| Before                                  | After                                                       |
+|-----------------------------------------|-------------------------------------------------------------|
+| `sun --json sunpump state T... --network nile`     | `sun --json sunpump state T...` (or `--network mainnet`)    |
+| Silent fallback / timeout                          | Hard error: `SunPump is only available on mainnet (got "nile")` |
+
+The mainnet router contract is unchanged:
+`TTfvyrAz86hbZk5iDpKD78pqLGgi8C7AAw`.
+
+#### 2. Upstream `sun-cli` SunPump command groups removed
+
+The following `sun sunpump *` subcommands were removed in `@bankofai/sun-cli ≥ 1.2.0` and are **no longer documented** in this skill:
+
+- `sunpump home` — `stats` / `data` / `banners`
+- `sunpump tx ticker` — server-capped at ~15 rows anyway
+- `sunpump kline` — v1 / v2 / v3
+- `sunpump red-packet` — `get` / `remain` / `by-user` / `summary`
+- `sunpump campaign` — `list` / `banners`
+- `sunpump referral` — `rewards` / `invites`
+- `sunpump admin-summary`
+- `sunpump quota`
+
+**Remaining surface** (what the skill targets and what `sun-cli` still
+ships):
+
+```
+token            tx token   tx user      portfolio
+state            quote-buy  quote-sell   buy        sell
+```
+
+### Migration Guide
+
+| If your agent did this…                          | Do this instead                                |
+|--------------------------------------------------|------------------------------------------------|
+| `sun ... sunpump <cmd> --network nile`           | Drop `--network` or use `--network mainnet`    |
+| `sun --json sunpump home stats`                  | Removed — no replacement (data not exposed)    |
+| `sun --json sunpump kline ...`                   | Removed — pull candles from a market data API  |
+| `sun --json sunpump red-packet ...`              | Removed — promotion endpoints retired          |
+| `sun --json sunpump campaign list`               | Removed — promotion endpoints retired          |
+| `sun --json sunpump referral rewards <addr>`     | Removed                                        |
+| `sun --json sunpump admin-summary`               | Removed                                        |
+| `sun --json sunpump quota`                       | Removed                                        |
+| `sun --json sunpump tx ticker`                   | Use `sun --json sunpump tx token <addr>` instead |
+
+### Documentation Updates
+
+- **Quick-start prerequisites** — `TRON_NETWORK` comment drops the
+  "or nile" hint.
+- **AI agent flag table** — `--network` documented as mainnet-only for
+  SunPump.
+- **Pre-launch trading section** — drops the "Network selection"
+  example.
+- **Pre-validation checklist** — explicitly requires `--network mainnet`
+  (or none) and notes the CLI's fast-fail behaviour.
+- **Known Limitations table** — replaces the legacy "silently falls back
+  to mainnet" and "Shasta unsupported" rows with a single
+  "mainnet only" row.
+- **Troubleshooting** — removes the "try the nile testnet" suggestion.
+
+### Compatibility
+
+- **Required runtime:** `@bankofai/sun-cli ≥ 1.2.0`
+- **Wallet:** unchanged — only `swap` / `sunpump buy` / `sunpump sell`
+  need `TRON_PRIVATE_KEY`, `TRON_MNEMONIC`, or `AGENT_WALLET_PASSWORD`.
+- **Read endpoints** (`token`, `portfolio`, `tx user`, `state`,
+  `quote-*`) still work without a wallet.
+
+### Install
+
+```bash
+# 1. Install the skill (Claude Code / Cursor / Codex pick it up)
+npx skills add BofAI/skills
+
+# 2. Install / upgrade the runtime CLI
+npm install -g @bankofai/sun-cli@^1.2.0
+```
+
+---
+
+## Previous Releases
+
+### v1.1.1 — 2026-05-21 _(docs only)_
+
+- README and `SKILL.md` now document how to install the skill itself
+  with `npx skills add` (vercel-labs/skills CLI), including monorepo
+  `--skill` selection, branch-pinned tree-URL form for pre-merge
+  installs, and the
+  [vercel-labs/skills#851](https://github.com/vercel-labs/skills/issues/851)
+  symlink workaround for `-g -a claude-code`.
+- Pinned runtime requirement to `@bankofai/sun-cli@^1.2.0`.
+
+### v1.1.0 — 2026-05-20
+
+**Added — pre-launch bonding-curve trading.** Filled the gap between
+token creation and SunSwap migration:
+
+- `sun sunpump state <addr>` — read on-chain state
+  (`NOT_EXIST` / `TRADING` / `READY_TO_LAUNCH` / `LAUNCHED`).
+- `sun sunpump quote-buy <addr> --trx <decimal>` — preview buy
+  (no wallet).
+- `sun sunpump quote-sell <addr> --amount <decimal> [--decimals 18]` —
+  preview sell (no wallet).
+- `sun sunpump buy <addr> --trx <decimal> [--slippage 0.05] [--min-out <raw>]`.
+- `sun sunpump sell <addr> --amount <decimal> [--decimals 18] [--slippage 0.05] [--min-out <raw>]`.
+
+**Changed**
+
+- Quick-start lists 7 flows (was 6); buy/sell split into post-launch
+  (`sun swap`) vs pre-launch (`sun sunpump buy/sell`) paths.
+- Agent Pre-Validation Checklist adds a Step 0 — `sunpump state` first —
+  to pick the right trade path.
+- Decimal inputs: `--trx <amount>` and `--amount <amount>` accept
+  human-readable values (e.g. `10`, `1.5`). The CLI scales by TRX→Sun
+  (×1e6) and token decimals before calling the contract.
+- Default slippage on the bonding-curve path is `0.05` (5%) — meme
+  tokens are volatile; the SDK default matches.
+
+**Notes**
+
+- `sun-kit`'s exported `SunPumpTokenState` enum lists only 0–2, but the
+  on-chain contract returns `3` for tokens fully launched on SunSwap.
+  The CLI re-labels `3 → LAUNCHED`; trust the printed label, not the
+  raw int.
+- First sell of a given token triggers an automatic TRC20
+  `approve(MaxUint256)` tx — only the final sell tx hash is returned.
+
+### v1.0.0 — 2026-05-20 _(initial release)_
+
+Six core SunPump flows via `@bankofai/sun-cli`:
+
+1. Buy and sell tokens through SunSwap — `sun swap` / `sun swap:quote`.
+2. User position check — `sun sunpump portfolio <walletAddress>`.
+3. Trade history — `sun sunpump tx user <walletAddress> --size 20`.
+4. Token info — `sun sunpump token get <contractAddress>`.
+5. Token ranking — `sun sunpump token ranking --type MARKET_CAP|VOLUME_24H|PRICE_CHANGE_24H --size 10`.
+6. Top holders — `sun sunpump token holders <contractAddress> --size 20`.
+
+---
+
+**Maintainer:** Bank of AI Team
+**License:** MIT — see [LICENSE](../LICENSE)

--- a/sunpump-agent-skill/SKILL.md
+++ b/sunpump-agent-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: SunPump Meme Token Toolkit
-description: Trade meme tokens on SunPump — both pre-launch (bonding curve via `sun sunpump buy/sell`) and post-launch (SunSwap via `sun swap`) — and query token info, rankings, holders, portfolios, and trade history.
-version: 1.2.0
+description: Create meme tokens on SunPump (`sun sunpump launch`), trade them — both pre-launch (bonding curve via `sun sunpump buy/sell`) and post-launch (SunSwap via `sun swap`) — and query token info, rankings, holders, portfolios, and trade history.
+version: 1.3.0
 dependencies:
   - "@bankofai/sun-cli"
 tags:
@@ -16,15 +16,16 @@ tags:
 
 ## Quick Start
 
-This skill enables AI agents to interact with **SunPump** — the meme-token launchpad on the TRON blockchain — through `sun-cli`. It covers the seven core flows an end user needs:
+This skill enables AI agents to interact with **SunPump** — the meme-token launchpad on the TRON blockchain — through `sun-cli`. It covers the eight core flows an end user needs:
 
-1. **Trade post-launch tokens** through SunSwap (`sun swap`)
-2. **Trade pre-launch tokens** on the SunPump bonding curve (`sun sunpump buy` / `sun sunpump sell`)
-3. **Check a wallet's positions** (`sun sunpump portfolio`)
-4. **View a wallet's trade history** (`sun sunpump tx user`)
-5. **Look up token info** (`sun sunpump token get`)
-6. **See token rankings** (`sun sunpump token ranking`)
-7. **List a token's top holders** (`sun sunpump token holders`)
+1. **Create (launch) a new meme token** (`sun sunpump launch`) — server-side creation, no wallet needed
+2. **Trade post-launch tokens** through SunSwap (`sun swap`)
+3. **Trade pre-launch tokens** on the SunPump bonding curve (`sun sunpump buy` / `sun sunpump sell`)
+4. **Check a wallet's positions** (`sun sunpump portfolio`)
+5. **View a wallet's trade history** (`sun sunpump tx user`)
+6. **Look up token info** (`sun sunpump token get`)
+7. **See token rankings** (`sun sunpump token ranking`)
+8. **List a token's top holders** (`sun sunpump token holders`)
 
 **Pre-launch vs post-launch decision** — choose the right trade command:
 
@@ -40,6 +41,7 @@ Always call `sun sunpump state <addr>` or `sun sunpump token get <addr>` first t
 > **Wallet required for trading only:** Run `agent-wallet list` first.
 > If no wallets exist, invoke `bankofai-guide` (Section C — Wallet Guard) before proceeding.
 > All read-only SunPump queries (portfolio, tx history, token info, ranking, holders) work without a wallet.
+> Token creation (`sun sunpump launch`) is server-side and also needs **no wallet**.
 
 1. **Install this skill** (once, picked up by Claude Code / Cursor / Codex):
    ```bash
@@ -47,9 +49,9 @@ Always call `sun sunpump state <addr>` or `sun sunpump token get <addr>` first t
    ```
 
 
-2. **Install sun-cli** (≥ 1.2.0 required — earlier versions lack `sunpump buy/sell/state`):
+2. **Install sun-cli** (≥ 1.2.1 required — earlier versions lack `sunpump launch`; ≥ 1.2.0 lacks only that but has `sunpump buy/sell/state`):
    ```bash
-   npm install -g @bankofai/sun-cli@^1.2.0
+   npm install -g @bankofai/sun-cli@^1.2.1
    ```
 
 3. **Configure wallet** (required for write commands — `sun swap`, `sun sunpump buy`, `sun sunpump sell`):
@@ -402,9 +404,59 @@ If `holders` results look thin, also call `sunpump token get <address>` and read
 
 ---
 
+### 8. Token Creation — `sun sunpump launch`
+
+Create a new meme token on SunPump through the agent endpoint (`POST /ai/agentTokenLaunch`). Creation is **server-side**: the platform signs and broadcasts the creation transaction, so **no wallet is required**. The new token starts on the bonding curve (state `1 TRADING`) and is immediately buyable via `sun sunpump buy`.
+
+```bash
+sun --json --yes sunpump launch \
+  --name "My Meme" \
+  --symbol MEME \
+  --description "The dankest meme on TRON" \
+  --image ./logo.png \
+  --twitter-url https://x.com/mymeme \
+  --telegram-url https://t.me/mymeme \
+  --website-url https://mymeme.example
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--name <name>` | ✓ | Token name |
+| `--symbol <symbol>` | ✓ | Token symbol (ticker) |
+| `--description <text>` | ✓ | Token description |
+| `--image <path>` | strongly recommended | Logo image file — read locally and sent as base64 |
+| `--image-base64 <data>` | | Logo as a raw base64 string (no data-URI prefix; overrides `--image`) |
+| `--twitter-url <url>` | | Twitter/X URL |
+| `--telegram-url <url>` | | Telegram URL |
+| `--website-url <url>` | | Website URL |
+| `--tweet-username <name>` | | Tweet username to associate with the launch |
+
+Returns the full token object including `contractAddress`, `createTxHash`, and `logoUrl`.
+
+> **WARNING: Provide a logo.** Launching without `--image` / `--image-base64` has been seen to fail with the opaque server error `Invoke third part error`. Always attach a logo image; if you hit that error, retry with `--image <path>`.
+
+> **NOTE: timestamp quirk in `--json` mode.** Unlike the GET endpoints (epoch seconds), the launch endpoint serializes `tokenCreatedInstant` / `tokenLaunchedInstant` / `firstReachHillInstant` as epoch-millis ÷ 1e6 (e.g. `1780476.327`). The CLI normalizes these only for the human-readable view — in `--json` mode you get the raw values. Multiply by 1000 to get epoch seconds.
+
+#### Dry-run first
+
+```bash
+sun --json --yes --dry-run sunpump launch --name "My Meme" --symbol MEME --description "..." --image ./logo.png
+```
+
+Prints the resolved parameters (including the image size) without calling the API — use this to show the user exactly what will be created.
+
+#### Verify after creation
+
+```bash
+sun --json sunpump token get <contractAddress>     # metadata is live
+sun --json sunpump state <contractAddress>         # expect state 1 (TRADING)
+```
+
+---
+
 ## Agent Pre-Validation Checklist
 
-Before executing any **write** operation (`sun swap`, `sun sunpump buy`, `sun sunpump sell`), the AI agent **must** perform these checks:
+Before executing any **write** operation (`sun swap`, `sun sunpump buy`, `sun sunpump sell`, `sun sunpump launch`), the AI agent **must** perform these checks:
 
 ### Step 0 — Decide which trade path to use
 
@@ -457,6 +509,25 @@ sun --json sunpump state <memeTokenAddress>
 4. **Validate slippage is reasonable.** Meme tokens often need 1–5% slippage; flag anything outside 0.001 (0.1%) – 0.10 (10%) for review.
 
 5. **Validate `--network`**. `sun swap` accepts `mainnet` / `nile` / `shasta` for general TRC20 pairs, but SunPump-migrated tokens are still mainnet-only — check the migration target before quoting on a non-mainnet network.
+
+### Before `sun sunpump launch` (token creation)
+
+1. **Confirm all three required fields with the user**: `--name`, `--symbol`, `--description`. Never invent or autofill these — they are permanent on-chain metadata.
+
+2. **Require a logo image.** Launching without one often fails with `Invoke third part error`. Ask the user for an image file path (or base64 data) before proceeding; verify the file exists and is a reasonable image (PNG/JPG, < 1 MB recommended).
+
+3. **Check for an existing token with the same symbol** to avoid confusing duplicates:
+   ```bash
+   sun --json sunpump token search <symbol>
+   ```
+   If close matches exist, surface them to the user and confirm intent.
+
+4. **Dry-run and show the user the exact payload** before the real call:
+   ```bash
+   sun --json --yes --dry-run sunpump launch --name "..." --symbol ... --description "..." --image ./logo.png
+   ```
+
+5. **Get explicit user confirmation, then launch once.** Token creation is irreversible — never retry a launch that may have succeeded; verify with `sun sunpump token search <symbol>` first.
 
 ### Before Read-Only Calls
 
@@ -587,6 +658,40 @@ sun --json sunpump tx user T... --swap-type BUY --size 20
 
 ---
 
+### Pattern 5 — Launch a New Token
+
+**Step 1 — Collect and confirm metadata with the user:** name, symbol, description, logo image, optional social links.
+
+**Step 2 — Check for symbol collisions:**
+
+```bash
+sun --json sunpump token search MEME
+```
+
+**Step 3 — Dry-run and show the user the payload:**
+
+```bash
+sun --json --yes --dry-run sunpump launch --name "My Meme" --symbol MEME --description "..." --image ./logo.png
+```
+
+**Step 4 — User confirms → launch (once):**
+
+```bash
+sun --json --yes sunpump launch --name "My Meme" --symbol MEME --description "..." --image ./logo.png \
+  --twitter-url https://x.com/mymeme --telegram-url https://t.me/mymeme --website-url https://mymeme.example
+```
+
+**Step 5 — Verify and hand back:**
+
+```bash
+sun --json sunpump token get <contractAddress>
+sun --json sunpump state <contractAddress>      # expect 1 (TRADING)
+```
+
+Show the user: contract address, creation tx hash (`createTxHash`), logo URL, and a Tronscan link (`https://tronscan.org/#/transaction/<createTxHash>`). The token is now live on the bonding curve and buyable via [Pattern 1b](#pattern-1b--pre-launch-buy-via-sun-sunpump-buy).
+
+---
+
 ## Security Rules
 
 ### CRITICAL: Never Display Private Keys
@@ -608,11 +713,22 @@ The AI agent **must never** execute `sun swap` or `sun sunpump buy/sell` without
 
 > **WARNING:** Do not pass `--yes` on the first call. Use `--yes` only after the user has reviewed the preview and confirmed.
 
+### CRITICAL: Always Preview Before Launching a Token
+
+`sun sunpump launch` creates a **permanent on-chain token**. Correct sequence:
+
+1. Collect `--name` / `--symbol` / `--description` / logo from the user — never invent them
+2. `sun --json sunpump token search <symbol>` — surface symbol collisions
+3. `sun --json --yes --dry-run sunpump launch ...` — show the user the exact payload
+4. **Ask the user to confirm**
+5. Execute once with `--yes`
+
 ### CRITICAL: Prevent Duplicate Transactions
 
 - One user command = one transaction
-- After a successful swap, mark it as done
+- After a successful swap or launch, mark it as done
 - Never silently retry a successful transaction
+- For `launch`: if the call errors ambiguously (timeout, opaque server error), check `sun sunpump token search <symbol>` before retrying — the token may already exist
 
 ### CRITICAL: Highlight Holder Concentration
 
@@ -646,6 +762,32 @@ Swap completed.
   Bought:      100 TRX → 812,344 PEPE
 ```
 
+**Before a token launch:**
+
+```
+About to create a new SunPump token (irreversible):
+  Name:        My Meme
+  Symbol:      MEME
+  Description: The dankest meme on TRON
+  Logo:        ./logo.png (24,310 bytes)
+  Socials:     x.com/mymeme • t.me/mymeme • mymeme.example
+
+No similarly-named token found on SunPump.
+
+Proceed with launch?
+```
+
+**After a successful launch:**
+
+```
+Token created.
+  Contract:  TXYZ...
+  Create Tx: abc123...
+  Explorer:  https://tronscan.org/#/transaction/abc123...
+  Logo:      https://.../logo.png
+  State:     TRADING (bonding curve) — buyable via `sun sunpump buy`
+```
+
 ---
 
 ## Known Limitations
@@ -662,6 +804,8 @@ Swap completed.
 | Invalid `--type` for ranking | `token ranking` | API rejects with non-obvious error | Only pass `MARKET_CAP`, `VOLUME_24H`, or `PRICE_CHANGE_24H` |
 | `--start-time` / `--end-time` are seconds, not ms | `tx user`, `tx token` | Ms values produce empty results | Use epoch seconds |
 | `percent` field magnitude differs by endpoint | `token holders` vs `token list` | Holders endpoint returns 38.51, list endpoint returns 0.3851 | The CLI normalizes, but check magnitude when consuming raw JSON |
+| Launch without a logo fails opaquely | `sunpump launch` | Server returns `Invoke third part error` when no image accompanies the launch | Always pass `--image <path>` (or `--image-base64`) |
+| Launch `*Instant` fields use a non-standard unit | `sunpump launch` (`--json` mode) | `tokenCreatedInstant` etc. come back as epoch-millis ÷ 1e6 (e.g. `1780476.327`), not epoch seconds | Multiply by 1000 for epoch seconds; the CLI only normalizes in human-readable mode |
 
 ---
 
@@ -688,8 +832,18 @@ The token has already migrated to SunSwap. Switch to `sun swap`.
 ### `sun sunpump sell` quote-sell reverts
 The token is in state 3 (LAUNCHED). The bonding-curve contract refuses sells once a token has migrated. Use `sun swap` instead.
 
+### `sun sunpump launch` fails with `Invoke third part error`
+The launch most likely lacked a logo image. Retry with `--image <path>` (or `--image-base64 <data>`). If it still fails, check the image is a valid PNG/JPG and try a smaller file.
+
+### `sun sunpump launch` timed out or returned an ambiguous error
+The token may still have been created server-side. Before retrying, check:
+```bash
+sun --json sunpump token search <symbol>
+```
+If the token exists, treat the launch as successful — do **not** launch again.
+
 ### "Wallet not configured" (write commands only)
-Set one of `TRON_PRIVATE_KEY`, `TRON_MNEMONIC`, or `AGENT_WALLET_PASSWORD`. Read-only sunpump commands do **not** need a wallet.
+Set one of `TRON_PRIVATE_KEY`, `TRON_MNEMONIC`, or `AGENT_WALLET_PASSWORD`. Read-only sunpump commands and `sunpump launch` do **not** need a wallet.
 
 ### Network error / timeout
 - Check internet
@@ -698,6 +852,6 @@ Set one of `TRON_PRIVATE_KEY`, `TRON_MNEMONIC`, or `AGENT_WALLET_PASSWORD`. Read
 
 ---
 
-**Version**: 1.2.0 (drops nile testnet — SunPump is now mainnet-only)
-**Last Updated**: 2026-05-22
+**Version**: 1.3.0 (adds token creation — `sun sunpump launch`)
+**Last Updated**: 2026-06-04
 **Maintainer**: Bank of AI Team

--- a/sunpump-agent-skill/SKILL.md
+++ b/sunpump-agent-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: SunPump Meme Token Toolkit
 description: Create meme tokens on SunPump (`sun sunpump launch`), trade them — both pre-launch (bonding curve via `sun sunpump buy/sell`) and post-launch (SunSwap via `sun swap`) — and query token info, rankings, holders, portfolios, and trade history.
-version: 1.3.0
+version: 1.3.1
 dependencies:
   - "@bankofai/sun-cli"
 tags:
@@ -437,13 +437,15 @@ Returns the full token object including `contractAddress`, `createTxHash`, and `
 
 > **NOTE: timestamp quirk in `--json` mode.** Unlike the GET endpoints (epoch seconds), the launch endpoint serializes `tokenCreatedInstant` / `tokenLaunchedInstant` / `firstReachHillInstant` as epoch-millis ÷ 1e6 (e.g. `1780476.327`). The CLI normalizes these only for the human-readable view — in `--json` mode you get the raw values. Multiply by 1000 to get epoch seconds.
 
+> **WARNING: mainnet only.** Like every `sunpump` subcommand, `launch` is mainnet-only. The `sunpump` command group runs a `preAction` guard that throws `SunPump is only available on mainnet (got "...")` for any non-mainnet `--network` — **before** the action runs, so it fires even on `--dry-run`. Drop `--network` or pass `--network mainnet`.
+
 #### Dry-run first
 
 ```bash
 sun --json --yes --dry-run sunpump launch --name "My Meme" --symbol MEME --description "..." --image ./logo.png
 ```
 
-Prints the resolved parameters (including the image size) without calling the API — use this to show the user exactly what will be created.
+Prints the resolved parameters (including the image size) without calling the API — use this to show the user exactly what will be created. The mainnet guard still applies (`--dry-run --network nile` errors out before previewing).
 
 #### Verify after creation
 
@@ -527,7 +529,9 @@ sun --json sunpump state <memeTokenAddress>
    sun --json --yes --dry-run sunpump launch --name "..." --symbol ... --description "..." --image ./logo.png
    ```
 
-5. **Get explicit user confirmation, then launch once.** Token creation is irreversible — never retry a launch that may have succeeded; verify with `sun sunpump token search <symbol>` first.
+5. **`--network` must be `mainnet`.** SunPump launch is mainnet-only; the `sunpump` group's `preAction` guard throws on any other value, including under `--dry-run`. Drop `--network` or pass `--network mainnet`.
+
+6. **Get explicit user confirmation, then launch once.** Token creation is irreversible — never retry a launch that may have succeeded; verify with `sun sunpump token search <symbol>` first.
 
 ### Before Read-Only Calls
 
@@ -852,6 +856,6 @@ Set one of `TRON_PRIVATE_KEY`, `TRON_MNEMONIC`, or `AGENT_WALLET_PASSWORD`. Read
 
 ---
 
-**Version**: 1.3.0 (adds token creation — `sun sunpump launch`)
-**Last Updated**: 2026-06-04
+**Version**: 1.3.1 (docs: `sun sunpump launch` is mainnet-only)
+**Last Updated**: 2026-06-08
 **Maintainer**: Bank of AI Team


### PR DESCRIPTION
…aunch)

- New flow #1: create a meme token via the SunPump agent endpoint (POST /ai/agentTokenLaunch) — server-side creation, no wallet needed
- SKILL.md: command reference section 8 with full flag table, dry-run and post-creation verification; pre-validation checklist, security rules, communication protocol and troubleshooting extended for launch
- Document known quirks: launch without a logo fails with "Invoke third part error"; *Instant fields in --json launch output are epoch-millis / 1e6 (CLI normalizes only in human mode)
- Requires @bankofai/sun-cli >= 1.2.1 (install pins bumped)
- Add RELEASE_NOTES.md entry for v1.3.0