### PR TITLE
feat(tronscan): add security checks and validation

### DIFF
--- a/tronscan-skill/CHANGELOG.md
+++ b/tronscan-skill/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- Add read-only security checks for accounts, tokens, URLs, transactions, multi-signature
+  permissions, and token approvals
+- Validate TRON addresses, transaction hashes, token identifiers, and URLs before querying APIs
+  that otherwise return silent default or partial results for malformed input
+- Add normalized assessment signals while preserving the complete TronScan response
+- Report incomplete upstream security responses as `unknown` instead of a clean result
+- Add offline tests plus live endpoint smoke-test coverage
+- Require token identifiers for TRC10/TRC20 address-history queries, matching the current API
+
 ## 1.0.0 (2026-02-28)
 
 - Initial release

--- a/tronscan-skill/README.md
+++ b/tronscan-skill/README.md
@@ -1,6 +1,6 @@
 # TronScan Data Lookup Skill
 
-AI agent skill for querying TRON blockchain data via the [TronScan API](https://docs.tronscan.org/).
+AI agent skill for querying TRON blockchain data and read-only security signals via the [TronScan API](https://docs.tronscan.org/).
 
 ## Quick Start
 
@@ -9,6 +9,7 @@ npm install
 node scripts/overview.js          # Chain dashboard
 node scripts/account.js <address> # Account lookup
 node scripts/token.js --price trx # TRX price
+node scripts/security.js account <address> # Read-only security check
 ```
 
 ## Scripts
@@ -23,6 +24,18 @@ node scripts/token.js --price trx # TRX price
 | `contract.js` | Smart contract info, energy usage, call analytics |
 | `transfer.js` | TRX/TRC10/TRC20 transfer history |
 | `overview.js` | Chain overview, TPS, witnesses, governance, market data |
+| `security.js` | Account, token, URL, transaction, multi-signature, and approval security signals |
+
+Security checks validate inputs locally and return a normalized assessment plus the complete
+TronScan response. `no_known_flags` means only that the current response contains no known flags;
+incomplete upstream responses are reported as `unknown`, and neither result guarantees safety.
+
+## Testing
+
+```bash
+npm test           # Offline validation and assessment tests
+npm run test:live  # Live smoke tests for all configured TronScan endpoints
+```
 
 See [SKILL.md](SKILL.md) for full documentation and usage examples.
 

--- a/tronscan-skill/SKILL.md
+++ b/tronscan-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: TronScan Data Lookup
-description: Query TRON blockchain data via the TronScan API — accounts, transactions, tokens, blocks, contracts, transfers, and chain statistics.
+description: Query TRON blockchain data and read-only security signals via the TronScan API — accounts, transactions, tokens, blocks, contracts, transfers, chain statistics, permissions, approvals, and phishing indicators.
 version: 1.0.0
 dependencies:
   - axios
@@ -17,13 +17,14 @@ tags:
   - contract
   - transfer
   - analytics
+  - security
 ---
 
 # TronScan Data Lookup Skill
 
 ## Overview
 
-This skill enables AI agents to query the TRON blockchain through the TronScan API. It provides eight Node.js scripts that cover all major data lookup operations: universal search, account details, transactions, token info, blocks, smart contracts, transfer history, and chain-level statistics.
+This skill enables AI agents to query the TRON blockchain through the TronScan API. It provides nine Node.js scripts that cover universal search, account details, transactions, token info, blocks, smart contracts, transfer history, chain-level statistics, and read-only security checks.
 
 All scripts output structured JSON to stdout and log progress to stderr, following the bankofai skill conventions.
 
@@ -187,8 +188,8 @@ Query TRX, TRC10, and TRC20 transfer history for addresses and contracts.
 
 ```bash
 node scripts/transfer.js --trx <address>                             # TRX transfers
-node scripts/transfer.js --trc20 <address> [--token <contract>]      # TRC20 transfers
-node scripts/transfer.js --trc10 <address> [--token <token_id>]      # TRC10 transfers
+node scripts/transfer.js --trc20 <address> --token <contract>        # TRC20 transfers
+node scripts/transfer.js --trc10 <address> --token <token_id>        # TRC10 transfers
 node scripts/transfer.js --trc20-contract <contract> [--addr <addr>] # By contract
 node scripts/transfer.js --internal <address>                        # Internal txns
 ```
@@ -196,6 +197,7 @@ node scripts/transfer.js --internal <address>                        # Internal 
 **Common options:**
 | Param | Description |
 |-------|-------------|
+| `--token` | Required contract address for `--trc20`, or token ID for `--trc10` |
 | `--direction` | `0`=all, `1`=incoming, `2`=outgoing |
 | `--start_timestamp` | Start time (ms) |
 | `--end_timestamp` | End time (ms) |
@@ -222,6 +224,53 @@ node scripts/overview.js --nodes                  # Network node map
 ```
 
 **When to use:** When a user asks about TRON network health, TPS, super representatives, governance, TRX supply, or market data.
+
+---
+
+### 9. Security Checks
+
+Query TronScan security signals without signing or broadcasting a transaction:
+
+```bash
+node scripts/security.js account <address>
+node scripts/security.js token <token-id-or-contract>
+node scripts/security.js url <public-url>
+node scripts/security.js transaction <hash> [hash ...]
+node scripts/security.js multisig <address>
+node scripts/security.js approvals <address>
+```
+
+| Mode | Checks |
+|------|--------|
+| `account` | Fraud history, spam memos, fraudulent token creation, stablecoin blacklist signal |
+| `token` | Token level, blacklist/supply capabilities, URL-like names, source visibility, proxy use |
+| `url` | TronScan phishing, scam, or malicious-link signal |
+| `transaction` | Risky tokens/addresses, zero-value transfers, same-tail impersonation, overall risk |
+| `multisig` | Owner/active permission structure and locally derived threshold observations |
+| `approvals` | Risky token approvals and unlimited risky allowances |
+
+Endpoint paths are defined in `resources/api_config.json`.
+
+The script validates Base58Check addresses and 64-character transaction hashes before querying.
+This is required because several TronScan security endpoints return default `false` values or omit
+invalid inputs instead of reporting an error. URL query parameters and fragments are removed before
+transmission so credentials or private query values are not sent to the API.
+
+Output is a JSON object with:
+
+- `query`: normalized mode and subject;
+- `assessment.status`: `no_known_flags`, `review_required`, or `unknown`;
+- `assessment.signals`: fields requiring review;
+- `assessment.unknownReasons`: missing or incomplete upstream security fields, when applicable;
+- `assessment.unresolved`: transaction hashes omitted by the upstream API, when applicable;
+- `data`: the complete TronScan response.
+
+Treat `no_known_flags` as a narrow statement about the current TronScan response, never as proof
+that an account, token, URL, transaction, permission structure, or approval is safe. Corroborate
+material decisions with contract source, transaction details, and another current source.
+
+**When to use:** Before interacting with an unfamiliar TRON address, token, DApp URL, transaction,
+multi-signature account, or existing token approval.
 
 ## Examples
 
@@ -265,6 +314,42 @@ node scripts/transfer.js --trc20 TDqSquXBgUCLYvYC4XZgrprLK589dkhSCf --token TR7N
 node scripts/overview.js
 ```
 
+### Check a token and an account before interacting
+
+```bash
+node scripts/security.js token TPYmHEhy5n8TCEfYGqW2rPxsghSfzghPDn
+node scripts/security.js account TT2T17KZhoDu47i2E4FWxfG79zdkEWkU9N
+```
+
+Representative account-check output:
+
+```json
+{
+  "query": {
+    "mode": "account",
+    "subject": "TT2T17KZhoDu47i2E4FWxfG79zdkEWkU9N"
+  },
+  "assessment": {
+    "status": "no_known_flags",
+    "signals": [],
+    "caveat": "TronScan signals are one data source, not proof that a target is safe."
+  },
+  "data": {
+    "send_ad_by_memo": false,
+    "has_fraud_transaction": false,
+    "fraud_token_creator": false,
+    "is_black_list": false
+  }
+}
+```
+
+### Review approvals and multi-signature permissions
+
+```bash
+node scripts/security.js approvals THSiB9MT2sCnAUgnYs9euMCY9aiZCD4HB5
+node scripts/security.js multisig THSiB9MT2sCnAUgnYs9euMCY9aiZCD4HB5
+```
+
 ## Error Handling
 
 All scripts handle errors consistently:
@@ -276,6 +361,8 @@ All scripts handle errors consistently:
 | `Request failed with status 404` | Endpoint not found or invalid params | Verify address/hash format |
 | `timeout of 15000ms exceeded` | API server slow or unreachable | Retry after a few seconds |
 | `ENOTFOUND` | No network connectivity | Check internet connection |
+| `Invalid TRON address` | Bad prefix, alphabet, length, or checksum | Re-copy the Base58Check address from a trusted source |
+| `assessment.status: unknown` | A transaction hash was omitted or expected security fields were missing upstream | Verify the target exists, then retry or use the corresponding lookup script |
 
 Scripts exit with code 1 on error and output `{ "error": "message" }` to stdout for machine parsing.
 
@@ -286,6 +373,10 @@ Scripts exit with code 1 on error and output `{ "error": "message" }` to stdout 
 - When no API key is set, requests go through the BofAI proxy (`ts.bankofai.io`) with no key header
 - Never embed private keys or wallet secrets in script invocations
 - All queries are **read-only GET requests** against the public TronScan API
+- Security checks send only public addresses, token IDs, transaction hashes, or a sanitized public URL
+- URL credentials are rejected; query parameters and fragments are stripped before transmission
+- Do not submit private/internal URLs or paths containing secrets; path components are not removed
+- A clear security response is not a guarantee of safety and must not override contradictory evidence
 - The API key should be rotated if ever exposed in logs or public repositories
 - Rate limit to **5 requests/second** maximum to avoid key revocation
 

--- a/tronscan-skill/package.json
+++ b/tronscan-skill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bankofai/tronscan-skill",
   "version": "1.0.0",
-  "description": "AI Agent skill for querying TRON blockchain data via the TronScan API",
+  "description": "AI Agent skill for querying TRON blockchain data and security signals via the TronScan API",
   "license": "MIT",
   "scripts": {
     "search": "node scripts/search.js",
@@ -11,7 +11,10 @@
     "block": "node scripts/block.js",
     "contract": "node scripts/contract.js",
     "transfer": "node scripts/transfer.js",
-    "overview": "node scripts/overview.js"
+    "overview": "node scripts/overview.js",
+    "security": "node scripts/security.js",
+    "test": "node tests/security.test.js",
+    "test:live": "node scripts/test_all.js"
   },
   "dependencies": {
     "axios": "^1.6.0"

--- a/tronscan-skill/resources/api_config.json
+++ b/tronscan-skill/resources/api_config.json
@@ -42,7 +42,13 @@
     "dailyAccounts": "/api/overview/dailyaccounts",
     "trxVolume": "/api/trx/volume",
     "funds": "/api/funds",
-    "nodemap": "/api/nodemap"
+    "nodemap": "/api/nodemap",
+    "securityAccount": "/api/security/account/data",
+    "securityToken": "/api/security/token/data",
+    "securityUrl": "/api/security/url/data",
+    "securityTransaction": "/api/security/transaction/data",
+    "securityMultisig": "/api/security/sign/data",
+    "securityApprovals": "/api/security/auth/data"
   },
   "defaults": {
     "limit": 20,

--- a/tronscan-skill/scripts/security.js
+++ b/tronscan-skill/scripts/security.js
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+/**
+ * security.js - Read-only TronScan security checks with strict local validation
+ *
+ * Usage:
+ *   node scripts/security.js account <address>
+ *   node scripts/security.js token <token-id-or-contract>
+ *   node scripts/security.js url <public-url>
+ *   node scripts/security.js transaction <hash> [hash ...]
+ *   node scripts/security.js multisig <address>
+ *   node scripts/security.js approvals <address>
+ */
+
+const crypto = require('crypto');
+const { apiGet, output, fatal, parseArgs, log } = require('./utils');
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const TX_HASH_RE = /^[0-9a-f]{64}$/i;
+const TRC10_ID_RE = /^\d+$/;
+const MAX_TRANSACTION_HASHES = 20;
+const CAVEAT = 'TronScan signals are one data source, not proof that a target is safe.';
+
+const MODE_ALIASES = {
+  auth: 'approvals',
+  approval: 'approvals',
+  approvals: 'approvals',
+  account: 'account',
+  token: 'token',
+  url: 'url',
+  transaction: 'transaction',
+  tx: 'transaction',
+  multisig: 'multisig',
+  'multi-sig': 'multisig',
+};
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest();
+}
+
+function decodeBase58(value) {
+  let number = 0n;
+  for (const character of value) {
+    const index = BASE58_ALPHABET.indexOf(character);
+    if (index === -1) return null;
+    number = number * 58n + BigInt(index);
+  }
+
+  let decoded = Buffer.alloc(0);
+  if (number !== 0n) {
+    let hex = number.toString(16);
+    if (hex.length % 2 !== 0) hex = `0${hex}`;
+    decoded = Buffer.from(hex, 'hex');
+  }
+
+  let leadingZeroes = 0;
+  while (leadingZeroes < value.length && value[leadingZeroes] === '1') leadingZeroes++;
+  return Buffer.concat([Buffer.alloc(leadingZeroes), decoded]);
+}
+
+function isValidTronAddress(value) {
+  if (typeof value !== 'string' || value.length !== 34 || !value.startsWith('T')) return false;
+  const decoded = decodeBase58(value);
+  if (!decoded || decoded.length !== 25 || decoded[0] !== 0x41) return false;
+
+  const payload = decoded.subarray(0, 21);
+  const expectedChecksum = sha256(sha256(payload)).subarray(0, 4);
+  return crypto.timingSafeEqual(decoded.subarray(21), expectedChecksum);
+}
+
+function requireTronAddress(value, label = 'address') {
+  const trimmed = String(value || '').trim();
+  if (!isValidTronAddress(trimmed)) {
+    throw new Error(`Invalid TRON ${label}: expected a Base58Check address beginning with T`);
+  }
+  return trimmed;
+}
+
+function requireTokenIdentifier(value) {
+  const trimmed = String(value || '').trim();
+  if (TRC10_ID_RE.test(trimmed)) return trimmed;
+  return requireTronAddress(trimmed, 'token contract address');
+}
+
+function normalizeTargetUrl(value) {
+  const trimmed = String(value || '').trim();
+  if (!trimmed) throw new Error('Missing URL');
+
+  const candidate = /^[a-z][a-z\d+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  let parsed;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    throw new Error('Invalid URL');
+  }
+
+  if (!['http:', 'https:'].includes(parsed.protocol) || !parsed.hostname) {
+    throw new Error('URL must use http or https and include a hostname');
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error('URL credentials must not be sent to the security service');
+  }
+
+  const queryStripped = Boolean(parsed.search || parsed.hash);
+  parsed.search = '';
+  parsed.hash = '';
+  return { value: parsed.toString(), queryStripped };
+}
+
+function requireTransactionHashes(values) {
+  const hashes = values
+    .flatMap(value => String(value).split(','))
+    .map(value => value.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (hashes.length === 0) throw new Error('At least one transaction hash is required');
+  if (hashes.length > MAX_TRANSACTION_HASHES) {
+    throw new Error(`At most ${MAX_TRANSACTION_HASHES} transaction hashes may be checked at once`);
+  }
+
+  const invalid = hashes.filter(hash => !TX_HASH_RE.test(hash));
+  if (invalid.length > 0) throw new Error('Every transaction hash must contain exactly 64 hexadecimal characters');
+  return [...new Set(hashes)];
+}
+
+function statusFor(signals, unresolved = []) {
+  if (signals.length > 0) return 'review_required';
+  if (unresolved.length > 0) return 'unknown';
+  return 'no_known_flags';
+}
+
+function hasAllOwnFields(data, fields) {
+  return Boolean(
+    data
+    && typeof data === 'object'
+    && fields.every(field => Object.prototype.hasOwnProperty.call(data, field)),
+  );
+}
+
+function unknownAssessment(reason, extra = {}) {
+  return {
+    status: 'unknown',
+    signals: [],
+    unknownReasons: [reason],
+    caveat: CAVEAT,
+    ...extra,
+  };
+}
+
+function assessAccount(data) {
+  const fields = ['send_ad_by_memo', 'has_fraud_transaction', 'fraud_token_creator', 'is_black_list'];
+  if (!hasAllOwnFields(data, fields)) {
+    return unknownAssessment('upstream_response_missing_account_security_fields');
+  }
+  const signals = fields.filter(field => data?.[field] === true);
+  return { status: statusFor(signals), signals, caveat: CAVEAT };
+}
+
+function assessToken(data) {
+  const expectedFields = [
+    'token_level',
+    'has_url',
+    'black_list_type',
+    'increase_total_supply',
+    'open_source',
+    'is_proxy',
+  ];
+  if (!hasAllOwnFields(data, expectedFields)) {
+    return unknownAssessment('upstream_response_missing_token_security_fields');
+  }
+
+  const signals = [];
+  if (String(data?.token_level) === '3') signals.push('token_level_suspicious');
+  if (String(data?.token_level) === '4') signals.push('token_level_unsafe');
+  if (data?.has_url === true) signals.push('name_or_symbol_contains_url');
+  if (Number(data?.black_list_type) === 1) signals.push('blacklist_capability');
+  if (Number(data?.increase_total_supply) === 1) signals.push('supply_can_increase');
+  if (data?.open_source === false) signals.push('contract_not_open_source');
+  if (data?.is_proxy === true) signals.push('proxy_contract');
+  return { status: statusFor(signals), signals, caveat: CAVEAT };
+}
+
+function assessUrl(data, queryStripped) {
+  const notes = queryStripped
+    ? ['Query parameters and fragments were removed before transmission.']
+    : [];
+  if (!hasAllOwnFields(data, ['cheat_url'])) {
+    return unknownAssessment('upstream_response_missing_url_security_field', notes.length ? { notes } : {});
+  }
+
+  const signals = data?.cheat_url === true ? ['flagged_url'] : [];
+  const assessment = { status: statusFor(signals), signals, caveat: CAVEAT };
+  if (notes.length) assessment.notes = notes;
+  return assessment;
+}
+
+function assessTransactions(data, requestedHashes) {
+  const records = data && typeof data === 'object' && !Array.isArray(data) ? data : {};
+  const normalizedRecords = new Map(Object.entries(records).map(([hash, value]) => [hash.toLowerCase(), value]));
+  const unresolved = requestedHashes.filter(hash => !normalizedRecords.has(hash));
+  const signals = [];
+
+  for (const hash of requestedHashes) {
+    const record = normalizedRecords.get(hash);
+    if (!record) continue;
+    for (const field of ['riskToken', 'zeroTransfer', 'riskAddress', 'sameTailAttach', 'riskTransaction']) {
+      if (record[field] === true) signals.push(`${hash}:${field}`);
+    }
+  }
+
+  return { status: statusFor(signals, unresolved), signals, unresolved, caveat: CAVEAT };
+}
+
+function permissionSignals(permission, prefix) {
+  if (!permission || !Array.isArray(permission.keys)) return [`${prefix}_permission_missing`];
+  const threshold = Number(permission.threshold);
+  const rawWeights = permission.keys.map(key => Number(key.weight));
+  const weights = rawWeights.filter(weight => Number.isFinite(weight) && weight > 0);
+  const totalWeight = weights.reduce((sum, weight) => sum + weight, 0);
+  const signals = [];
+
+  if (rawWeights.some(weight => !Number.isFinite(weight) || weight <= 0)) {
+    signals.push(`${prefix}_invalid_key_weight`);
+  }
+  if (!Number.isFinite(threshold) || threshold <= 0) {
+    signals.push(`${prefix}_invalid_threshold`);
+  } else {
+    if (totalWeight < threshold) signals.push(`${prefix}_threshold_unreachable`);
+    if (weights.some(weight => weight >= threshold)) signals.push(`${prefix}_single_key_can_authorize`);
+  }
+  return signals;
+}
+
+function assessMultisig(data) {
+  if (!hasAllOwnFields(data, ['multiSign'])) {
+    return unknownAssessment('upstream_response_missing_multisig_status');
+  }
+  if (data?.multiSign !== true) {
+    return { status: 'no_known_flags', signals: [], observations: ['multi_signature_not_enabled'], caveat: CAVEAT };
+  }
+
+  const signals = permissionSignals(data.ownerPermission, 'owner');
+  if (!Array.isArray(data.activePermissions)) {
+    signals.push('active_permissions_missing');
+  } else {
+    for (const permission of data.activePermissions) {
+      signals.push(...permissionSignals(permission, `active_${permission.id ?? 'unknown'}`));
+    }
+  }
+
+  return {
+    status: statusFor(signals),
+    signals,
+    observations: ['multi_signature_enabled'],
+    caveat: CAVEAT,
+  };
+}
+
+function assessApprovals(data) {
+  const countFields = [
+    'approveRiskContractCount',
+    'approveRiskAccountCount',
+    'approveRiskAddressCount',
+  ];
+  if (!hasAllOwnFields(data, countFields)) {
+    return unknownAssessment('upstream_response_missing_approval_security_fields');
+  }
+
+  const signals = countFields
+    .filter(field => Number(data?.[field]) > 0)
+    .map(field => `${field}:${data[field]}`);
+
+  const riskApprovals = Array.isArray(data?.riskApprove) ? data.riskApprove : [];
+  for (const approval of riskApprovals) {
+    if (approval?.unlimited === true) {
+      signals.push(`unlimited_risky_approval:${approval.contract_address}:${approval.to_address}`);
+    }
+  }
+  return { status: statusFor(signals), signals, caveat: CAVEAT };
+}
+
+function assess(mode, data, context = {}) {
+  if (mode === 'account') return assessAccount(data);
+  if (mode === 'token') return assessToken(data);
+  if (mode === 'url') return assessUrl(data, context.queryStripped);
+  if (mode === 'transaction') return assessTransactions(data, context.hashes);
+  if (mode === 'multisig') return assessMultisig(data);
+  if (mode === 'approvals') return assessApprovals(data);
+  throw new Error(`Unsupported security mode: ${mode}`);
+}
+
+function usage() {
+  return [
+    'Usage:',
+    '  node scripts/security.js account <address>',
+    '  node scripts/security.js token <token-id-or-contract>',
+    '  node scripts/security.js url <public-url>',
+    '  node scripts/security.js transaction <hash> [hash ...]',
+    '  node scripts/security.js multisig <address>',
+    '  node scripts/security.js approvals <address>',
+  ].join('\n');
+}
+
+async function main() {
+  const { positional } = parseArgs(process.argv);
+  const mode = MODE_ALIASES[String(positional[0] || '').toLowerCase()];
+  if (!mode) throw new Error(usage());
+
+  let endpoint;
+  let params;
+  let subject;
+  const context = {};
+
+  if (mode === 'account' || mode === 'multisig' || mode === 'approvals') {
+    subject = requireTronAddress(positional[1]);
+    endpoint = { account: 'securityAccount', multisig: 'securityMultisig', approvals: 'securityApprovals' }[mode];
+    params = { address: subject };
+  } else if (mode === 'token') {
+    subject = requireTokenIdentifier(positional[1]);
+    endpoint = 'securityToken';
+    params = { address: subject };
+  } else if (mode === 'url') {
+    const normalized = normalizeTargetUrl(positional[1]);
+    subject = normalized.value;
+    context.queryStripped = normalized.queryStripped;
+    endpoint = 'securityUrl';
+    params = { url: subject };
+  } else {
+    context.hashes = requireTransactionHashes(positional.slice(1));
+    subject = context.hashes;
+    endpoint = 'securityTransaction';
+    params = { hashes: context.hashes.join(',') };
+  }
+
+  log(`Running ${mode} security check...`);
+  const data = await apiGet(endpoint, params);
+  output({
+    query: { mode, subject },
+    assessment: assess(mode, data, context),
+    data,
+  });
+}
+
+if (require.main === module) {
+  main().catch(error => fatal(error.message));
+}
+
+module.exports = {
+  assess,
+  assessAccount,
+  assessApprovals,
+  assessMultisig,
+  assessToken,
+  assessTransactions,
+  assessUrl,
+  decodeBase58,
+  isValidTronAddress,
+  normalizeTargetUrl,
+  permissionSignals,
+  requireTokenIdentifier,
+  requireTransactionHashes,
+  requireTronAddress,
+  unknownAssessment,
+};

--- a/tronscan-skill/scripts/test_all.js
+++ b/tronscan-skill/scripts/test_all.js
@@ -18,13 +18,20 @@ const tests = [
   { name: 'contract', fn: () => apiGet('contract', { contract: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t' }), check: d => d.data && d.data.length > 0 },
   { name: 'contract --list', fn: () => apiGet('contracts', { sort: '-trxCount', limit: 3 }), check: d => (d.data && d.data.length > 0) || d.total > 0 },
   { name: 'transfer --trx', fn: () => apiGet('transferTrx', { address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t', limit: 2 }), check: d => 'data' in d || 'code' in d },
-  { name: 'transfer --trc20', fn: () => apiGet('transferTrc20', { address: 'TKoJZgr58dCdwCv85deVgFkcrJPnBRiTio', limit: 2 }), check: d => 'data' in d || 'code' in d },
+  { name: 'transfer --trc20', fn: () => apiGet('transferTrc20', { address: 'TKoJZgr58dCdwCv85deVgFkcrJPnBRiTio', trc20Id: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t', limit: 2 }), check: d => Array.isArray(d.data) },
+  { name: 'transfer --trc10', fn: () => apiGet('transferTrc10', { address: 'TWd4WrZ9wn84f5x1hZhL4DHvk738ns5jwb', trc10Id: '1002000', limit: 2 }), check: d => Array.isArray(d.data) },
   { name: 'transfer --trc20-contract', fn: () => apiGet('trc20Transfers', { contract_address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t', limit: 2 }), check: d => (d.token_transfers && d.token_transfers.length > 0) || d.total > 0 },
   { name: 'overview (homepage)', fn: () => apiGet('homepage'), check: d => d.tps !== undefined },
   { name: 'overview --tps', fn: () => apiGet('tps'), check: d => d.data && d.data.currentTps > 0 },
   { name: 'overview --witnesses', fn: () => apiGet('witnesses', { limit: 3 }), check: d => (d.data && d.data.length > 0) || d.total > 0 },
   { name: 'overview --params', fn: () => apiGet('chainParams'), check: d => (d.tpiList && d.tpiList.length > 0) || Object.keys(d).length > 0 },
   { name: 'overview --funds', fn: () => apiGet('funds'), check: d => Object.keys(d).length > 0 },
+  { name: 'security account', fn: () => apiGet('securityAccount', { address: 'TT2T17KZhoDu47i2E4FWxfG79zdkEWkU9N' }), check: d => ['send_ad_by_memo', 'has_fraud_transaction', 'fraud_token_creator', 'is_black_list'].every(k => typeof d[k] === 'boolean') },
+  { name: 'security token', fn: () => apiGet('securityToken', { address: 'TPYmHEhy5n8TCEfYGqW2rPxsghSfzghPDn' }), check: d => d.token_level !== undefined && typeof d.has_url === 'boolean' },
+  { name: 'security URL', fn: () => apiGet('securityUrl', { url: 'https://www.google.com.hk/' }), check: d => typeof d.cheat_url === 'boolean' },
+  { name: 'security transaction', fn: () => apiGet('securityTransaction', { hashes: 'cfaad8dfd5c6842589fe6a4dafa810a50397ad58035639242dc02e53360e471b' }), check: d => d.cfaad8dfd5c6842589fe6a4dafa810a50397ad58035639242dc02e53360e471b !== undefined },
+  { name: 'security multisig', fn: () => apiGet('securityMultisig', { address: 'THSiB9MT2sCnAUgnYs9euMCY9aiZCD4HB5' }), check: d => typeof d.multiSign === 'boolean' },
+  { name: 'security approvals', fn: () => apiGet('securityApprovals', { address: 'THSiB9MT2sCnAUgnYs9euMCY9aiZCD4HB5' }), check: d => ['approveRiskContractCount', 'approveRiskAccountCount', 'approveRiskAddressCount'].every(k => d[k] !== undefined) },
 ];
 
 (async () => {

--- a/tronscan-skill/scripts/transfer.js
+++ b/tronscan-skill/scripts/transfer.js
@@ -4,8 +4,8 @@
  *
  * Usage:
  *   node scripts/transfer.js --trx <address>                             # TRX transfers
- *   node scripts/transfer.js --trc20 <address> [--token <contract>]      # TRC20 transfers
- *   node scripts/transfer.js --trc10 <address> [--token <token_id>]      # TRC10 transfers
+ *   node scripts/transfer.js --trc20 <address> --token <contract>        # TRC20 transfers
+ *   node scripts/transfer.js --trc10 <address> --token <token_id>        # TRC10 transfers
  *   node scripts/transfer.js --trc20-contract <contract> [--addr <addr>] # TRC20 transfers by contract
  *   node scripts/transfer.js --internal <address>                        # Internal transactions
  *
@@ -47,9 +47,9 @@ async function main() {
   if (args.trc20) {
     const address = typeof args.trc20 === 'string' ? args.trc20 : positional[0];
     if (!address) fatal('--trc20 requires an address');
+    if (!args.token || typeof args.token !== 'string') fatal('--trc20 requires --token <contract>');
     log(`Fetching TRC20 transfers for ${address}...`);
-    const params = { ...commonParams, address };
-    if (args.token) params.trc20Id = args.token;
+    const params = { ...commonParams, address, trc20Id: args.token };
     const data = await apiGet('transferTrc20', params);
     output(data);
     return;
@@ -58,9 +58,9 @@ async function main() {
   if (args.trc10) {
     const address = typeof args.trc10 === 'string' ? args.trc10 : positional[0];
     if (!address) fatal('--trc10 requires an address');
+    if (!args.token || typeof args.token !== 'string') fatal('--trc10 requires --token <token_id>');
     log(`Fetching TRC10 transfers for ${address}...`);
-    const params = { ...commonParams, address };
-    if (args.token) params.trc10Id = args.token;
+    const params = { ...commonParams, address, trc10Id: args.token };
     const data = await apiGet('transferTrc10', params);
     output(data);
     return;

--- a/tronscan-skill/tests/security.test.js
+++ b/tronscan-skill/tests/security.test.js
@@ -1,0 +1,161 @@
+const assert = require('assert');
+
+const {
+  assessAccount,
+  assessApprovals,
+  assessMultisig,
+  assessToken,
+  assessTransactions,
+  assessUrl,
+  isValidTronAddress,
+  normalizeTargetUrl,
+  requireTokenIdentifier,
+  requireTransactionHashes,
+} = require('../scripts/security');
+
+let passed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    console.error(`not ok - ${name}`);
+    throw error;
+  }
+}
+
+test('validates TRON Base58Check addresses instead of checking the prefix only', () => {
+  assert.equal(isValidTronAddress('TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t'), true);
+  assert.equal(isValidTronAddress('TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj61'), false);
+  assert.equal(isValidTronAddress('TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6u'), false);
+});
+
+test('accepts either a TRC10 id or a valid token contract address', () => {
+  assert.equal(requireTokenIdentifier('1002000'), '1002000');
+  assert.equal(requireTokenIdentifier('TPYmHEhy5n8TCEfYGqW2rPxsghSfzghPDn'), 'TPYmHEhy5n8TCEfYGqW2rPxsghSfzghPDn');
+  assert.throws(() => requireTokenIdentifier('USDD'));
+});
+
+test('normalizes public URLs and removes query data before transmission', () => {
+  const normalized = normalizeTargetUrl('example.com/app?token=secret#section');
+  assert.equal(normalized.value, 'https://example.com/app');
+  assert.equal(normalized.queryStripped, true);
+  assert.throws(() => normalizeTargetUrl('ftp://example.com/file'));
+  assert.throws(() => normalizeTargetUrl('https://user:password@example.com/'));
+});
+
+test('validates, lowercases, and deduplicates transaction hashes', () => {
+  const first = 'A'.repeat(64);
+  const second = 'b'.repeat(64);
+  assert.deepEqual(requireTransactionHashes([`${first},${second}`, first]), [first.toLowerCase(), second]);
+  assert.throws(() => requireTransactionHashes(['xyz']));
+});
+
+test('maps account risk booleans to review signals', () => {
+  const result = assessAccount({
+    send_ad_by_memo: false,
+    has_fraud_transaction: true,
+    fraud_token_creator: false,
+    is_black_list: true,
+  });
+  assert.equal(result.status, 'review_required');
+  assert.deepEqual(result.signals, ['has_fraud_transaction', 'is_black_list']);
+});
+
+test('does not treat an incomplete upstream response as a clean security result', () => {
+  const account = assessAccount({ send_ad_by_memo: false });
+  const token = assessToken({ token_level: '1' });
+  const url = assessUrl({}, true);
+  const multisig = assessMultisig({});
+  const approvals = assessApprovals({ approveRiskContractCount: 0 });
+
+  for (const result of [account, token, url, multisig, approvals]) {
+    assert.equal(result.status, 'unknown');
+    assert.equal(result.signals.length, 0);
+    assert.equal(result.unknownReasons.length, 1);
+  }
+  assert.deepEqual(url.notes, ['Query parameters and fragments were removed before transmission.']);
+});
+
+test('treats token capabilities as review signals without declaring the token malicious', () => {
+  const result = assessToken({
+    token_level: '3',
+    has_url: true,
+    black_list_type: 1,
+    increase_total_supply: 1,
+    open_source: false,
+    is_proxy: true,
+  });
+  assert.equal(result.status, 'review_required');
+  assert(result.signals.includes('token_level_suspicious'));
+  assert(result.signals.includes('proxy_contract'));
+});
+
+test('reports valid-looking transaction hashes that the API omits as unresolved', () => {
+  const found = 'a'.repeat(64);
+  const missing = 'b'.repeat(64);
+  const result = assessTransactions({
+    [found]: {
+      riskToken: false,
+      zeroTransfer: false,
+      riskAddress: false,
+      sameTailAttach: false,
+      riskTransaction: false,
+    },
+  }, [found, missing]);
+  assert.equal(result.status, 'unknown');
+  assert.deepEqual(result.unresolved, [missing]);
+});
+
+test('detects unreachable and single-key multi-signature thresholds', () => {
+  const result = assessMultisig({
+    multiSign: true,
+    ownerPermission: {
+      threshold: 3,
+      keys: [{ address: 'T1', weight: 1 }, { address: 'T2', weight: 1 }],
+    },
+    activePermissions: [{
+      id: 2,
+      threshold: 1,
+      keys: [{ address: 'T1', weight: 1 }, { address: 'T2', weight: 1 }],
+    }],
+  });
+  assert(result.signals.includes('owner_threshold_unreachable'));
+  assert(result.signals.includes('active_2_single_key_can_authorize'));
+});
+
+test('handles missing active permissions and invalid weights without throwing', () => {
+  const missing = assessMultisig({
+    multiSign: true,
+    ownerPermission: { threshold: 1, keys: [{ weight: 1 }] },
+  });
+  assert(missing.signals.includes('active_permissions_missing'));
+
+  const invalidWeight = assessMultisig({
+    multiSign: true,
+    ownerPermission: { threshold: 1, keys: [{ weight: 0 }] },
+    activePermissions: [],
+  });
+  assert(invalidWeight.signals.includes('owner_invalid_key_weight'));
+  assert(invalidWeight.signals.includes('owner_threshold_unreachable'));
+});
+
+test('surfaces risk counters and unlimited risky approvals', () => {
+  const result = assessApprovals({
+    approveRiskContractCount: 1,
+    approveRiskAccountCount: 0,
+    approveRiskAddressCount: 1,
+    riskApprove: [{
+      unlimited: true,
+      contract_address: 'TOKEN',
+      to_address: 'SPENDER',
+    }],
+  });
+  assert.equal(result.status, 'review_required');
+  assert(result.signals.includes('approveRiskContractCount:1'));
+  assert(result.signals.includes('unlimited_risky_approval:TOKEN:SPENDER'));
+});
+
+console.log(`${passed} tests passed`);


### PR DESCRIPTION
## Summary

- Add a read-only `security.js` command for TronScan account, token, URL, transaction, multi-signature permission, and token-approval security signals.
- Validate TRON Base58Check addresses, token identifiers, transaction hashes, and URLs locally before querying; strip URL query strings and fragments before transmission.
- Return a normalized assessment while preserving the complete upstream response, and report incomplete responses as `unknown` rather than a clean result.
- Require token identifiers for TRC10/TRC20 address-history queries and update their smoke tests to match the current TronScan API contract.
- Rebuild the contribution from the latest `develop` as requested in #71.

## Branch routing

- [x] Ordinary work targets `develop` from `feature/*`.
- [ ] A `main` PR comes only from `release_*` or `hotfix/*`.
- [ ] Release and hotfix changes will also be merged into `develop`.

## Skill checks

- [x] Changed `SKILL.md` files have valid YAML frontmatter.
- [x] Dependencies and supported versions are documented consistently.
- [x] Examples, resources, JSON files, and scripts were validated where applicable.
- [x] Security, confirmation, secret-handling, network, and fee implications were reviewed.
- [x] README and changelog entries were updated when behavior or the public catalog changed.

## Verification

Commands run from `tronscan-skill/`:

```bash
node --check scripts/security.js
node --check scripts/transfer.js
node --check scripts/test_all.js
node tests/security.test.js
node scripts/test_all.js
```

Results:

- Offline validation and assessment tests: **11/11 passed**
- Live smoke tests across all configured TronScan endpoints: **30/30 passed**
- Skill frontmatter, JSON resources, package metadata, changed-file scope, and `git diff --check` passed
- Branch comparison against `develop`: one commit ahead, zero behind

## Release workflow

- Keep `SKILL.md`, `package.json`, and `package-lock.json` at the current `1.0.0` version.
- Record the behavior changes under `Unreleased` instead of creating a dated `1.1.0` release entry.
- PR #75 is still open and has not added `private: true` to `develop` yet. If it lands before this PR, that field will be preserved while synchronizing the branch.

## Security

- All new API operations are read-only GET requests.
- No wallet, signing, private-key, or transaction-broadcast path is introduced.
- URL credentials are rejected; query strings and fragments are removed before transmission.
- `no_known_flags` is documented as not being proof that a target is safe.

## Previous PR

This replaces #71 following the maintainer-requested branch and release-workflow migration.